### PR TITLE
Automatic Per-suite Layouts

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -63,12 +63,28 @@ module Kitchen
         provisioner.calculate_path('hiera.yaml', :file)
       end
 
+      default_config :puppetfile_path do |provisioner|
+        provisioner.calculate_path('Puppetfile', :file)
+      end
+
       default_config :puppet_debug, false
       default_config :puppet_verbose, false
       default_config :puppet_noop, false
       default_config :puppet_platform, ''
       default_config :update_package_repos, true
       default_config :custom_facts, {}
+
+      def calculate_path(path, type = :directory)
+        base = File.join(config[:kitchen_root], 'puppet')
+        candidates = []
+        candidates << File.join(base, instance.suite.name, path)
+        candidates << File.join(base, path)
+        candidates << File.join(Dir.pwd, path)
+
+        candidates.find do |c|
+          type == :directory ? File.directory?(c) : File.file?(c)
+        end
+      end
 
       def install_command
         return unless config[:require_puppet_omnibus] or config[:require_puppet_repo]
@@ -236,7 +252,7 @@ module Kitchen
         end
 
         def puppetfile
-          File.join(config[:kitchen_root], 'Puppetfile')
+          config[:puppetfile_path] or ''
         end
 
         def manifest

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -4,7 +4,7 @@
 key | default value | Notes
 ----|---------------|--------
 puppet_version | "latest"| desired version, affects apt installs
-puppet_platform | naively tries to determine | OS platform of server 
+puppet_platform | naively tries to determine | OS platform of server
 require_puppet_repo | true | Set if using a puppet install from yum or apt repo
 puppet_apt_repo | "http://apt.puppetlabs.com/puppetlabs-release-precise.deb"| apt repo
 puppet_yum_repo | "https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm"| yum repo
@@ -22,8 +22,10 @@ puppet_noop| false| puppet runs in a no-op or dry-run mode
 update_package_repos| true| update OS repository metadata
 custom_facts| Hash.new | Hash to set the puppet facts before running puppet apply
 chef_bootstrap_url |"https://www.getchef.com/chef/install.sh"| the chef (needed for busser to run tests)
+puppetfile_path | | Path to Puppetfile
 
-##Configuring Provisioner Options
+## Configuring Provisioner Options
+
 The provisioner can be configured globally or per suite, global settings act as defaults for all suites, you can then customise per suite, for example:
 
     ---
@@ -48,3 +50,19 @@ The provisioner can be configured globally or per suite, global settings act as 
 
 
 in this example, vagrant will download a box for ubuntu 1204 with no configuration management installed, then install the latest puppet and puppet apply against a puppet repo from the /repository/puppet_repo directory using the defailt manifest site.pp
+
+To override a setting at the suite-level, specify the setting name under the suite:
+
+    suites:
+     - name: default
+       manifest: default.yaml
+
+### Per-suite Structure
+
+It can be beneficial to keep different Puppet layouts for different suites. Rather than having to specify the manifest, modules, etc for each suite, you can create the following directory structure and they will automatically be found:
+
+    $kitchen_root/puppet/$suite_name/manifests
+    $kitchen_root/puppet/$suite_name/modules
+    $kitchen_root/puppet/$suite_name/hiera
+    $kitchen_root/puppet/$suite_name/hiera.yaml
+    $kitchen_root/puppet/$suite_name/Puppetfile


### PR DESCRIPTION
This commit adds the ability to automatically detect per-suite Puppet
layouts. By using this, you don't have to manually specify the
location of the manifests, modules, etc for each suite.

This commit also adds the ability to specify the location of
the Puppetfile.

Documentation is also updated.
