### PR TITLE
Fixes documentation typo

### DIFF
--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -55,7 +55,7 @@ To override a setting at the suite-level, specify the setting name under the sui
 
     suites:
      - name: default
-       manifest: default.yaml
+       manifest: foobar.pp
 
 ### Per-suite Structure
 


### PR DESCRIPTION
Just noticed that my last pull request had a bad setting in the example.
