### PR TITLE
bugfix: remove destination before copying modules

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -353,7 +353,8 @@ module Kitchen
 
           tmp_modules_dir = File.join(sandbox_path, 'modules')
           FileUtils.mkdir_p(tmp_modules_dir)
-          FileUtils.cp_r(Dir.glob("#{modules}/*"), tmp_modules_dir)
+          FileUtils.cp_r(Dir.glob("#{modules}/*"), tmp_modules_dir,
+            :remove_destination => true)
         end
 
         def prepare_hiera_config


### PR DESCRIPTION
When using a `Puppetfile`, the user may have already run `librarian-puppet install` (or `r10k`) in his local folder and created all modules inside `modules/`. When the provisioner is now run (`kitchen converge`) it will produce an error (example for ntp module):

```
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #converge action: [Permission denied - /tmp/default-nocm-ubuntu-1204-sandbox-20140509-11381-c0jrxv/modules/ntp/templates/ntp.conf.erb]
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

This can be avoided by removing the destination files first. The destination files are created from the internal `librarian-puppet` run and can be overwritten if the user has these files in his local folder. This way the user can make adjustment to upstream modules and get them pulled in. All other modules that don't exist yet, will be pulled in as usual from librarian.

Signed-off-by: Dominik Richter dominik.richter@gmail.com
