### PR TITLE
Fix Dependency Issue with Puppet Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 
 Gemfile.lock
 
+# Also ignore any locally built gems
+*.gem
+
 # And because this is Ruby, ignore the following
 #  (source: https://github.com/github/gitignore/blob/master/Ruby.gitignore):
 

--- a/lib/kitchen-puppet/version.rb
+++ b/lib/kitchen-puppet/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Puppet
-    VERSION = "0.0.12"
+    VERSION = "0.0.13"
   end
 end

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -147,6 +147,7 @@ module Kitchen
             #{sudo('wget')} #{puppet_apt_repo}
             #{sudo('dpkg')} -i #{puppet_apt_repo_file}
             #{update_packages_debian_cmd}
+            #{sudo('apt-get')} -y install puppet-common#{puppet_debian_version}
             #{sudo('apt-get')} -y install puppet#{puppet_debian_version}
           fi
           #{install_busser}
@@ -173,6 +174,7 @@ module Kitchen
                #{sudo('wget')} #{puppet_apt_repo}
                #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                #{update_packages_debian_cmd}
+               #{sudo('apt-get')} -y install puppet-common#{puppet_debian_version}
                #{sudo('apt-get')} -y install puppet#{puppet_debian_version}
             fi
           fi

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -3,7 +3,7 @@
 
 key | default value | Notes
 ----|---------------|--------
-puppet_version | "latest"| desired version, affects apt installs
+puppet_version | "latest"| desired version, affects apt installs.
 puppet_platform | naively tries to determine | OS platform of server
 require_puppet_repo | true | Set if using a puppet install from yum or apt repo
 puppet_apt_repo | "http://apt.puppetlabs.com/puppetlabs-release-precise.deb"| apt repo
@@ -68,3 +68,8 @@ It can be beneficial to keep different Puppet layouts for different suites. Rath
     $kitchen_root/puppet/$suite_name/hiera
     $kitchen_root/puppet/$suite_name/hiera.yaml
     $kitchen_root/puppet/$suite_name/Puppetfile
+
+### Puppet Version
+When specifying a puppet version, you must use this format: "3.6.2-1puppetlabs1". I have
+no idea why Puppet versioned their repository with a trailing
+"-1puppetlabs1", but there it is. 


### PR DESCRIPTION
When running the puppet-apply provisioner with a previous version of puppet than the
release package of the repository selected, there was a dependency issue where
puppet-common would need to be installed at that matching version _before_ installing
puppet at that version, yet puppet-common would be slated to install as the latest
version.

Only noticed issue on Debian/Ubuntu builds, did not test CentOS/RHEL flavors of Linux.
This is a critical issue for installing any version of puppet in test-kitchen that is a
lower version tag than the current release.

Also added an entry in gitignore to ignore any .gem files that are locally built during
gem development.

As well as added documentation for version numbers in the provisioner_options markdown
document.

Signed-off-by: "Jake Champlin" jake.champlin@minted.com
