### PR TITLE
Fixed metadata.json module name parsing

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -502,7 +502,7 @@ module Kitchen
           if File.exists?(metadata_json)
             module_name = nil
             begin
-              module_name = JSON.parse(IO.read(metadata_json))['name'].split('/').last
+              module_name = JSON.parse(IO.read(metadata_json))['name'].split('-').last
             rescue
               error("not able to load or parse #{metadata_json_path} for the name of the module")
             end


### PR DESCRIPTION
The module name inside the metadata.json is expected in the following
format: username-module instead username/module!

---

Source: https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#another-note-on-module-names

Another note on module names
Although the Puppet Forge expects to receive modules named username-
module, its web interface presents them as username/module. There isn’t
a good reason for this, and we are working on reconciling the two; in
the meantime, be sure to always use the username-module style in your
## metadata files and when issuing commands.
