### PR TITLE
Adds facter_file config parameter to puppet_apply

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -115,6 +115,7 @@ module Kitchen
       default_config :update_package_repos, true
       default_config :remove_puppet_repo, false
       default_config :custom_facts, {}
+      default_config :facter_file, nil
       default_config :librarian_puppet_ssl_file, nil
       
       default_config :hiera_eyaml, false
@@ -337,6 +338,7 @@ module Kitchen
           else
             [
               custom_facts,
+              facter_facts,
               sudo('puppet'),
               'apply',
               File.join(config[:root_path], 'manifests', manifest),
@@ -479,6 +481,17 @@ module Kitchen
           bash_vars = "export #{bash_vars};"
           debug(bash_vars)
           bash_vars
+        end
+
+        def facter_facts
+          return nil unless config[:facter_file]
+          fact_vars = "export "
+          fact_hash = YAML.load_file(config[:facter_file])
+          fact_hash.each do |key, value|
+            fact_vars << "FACTER_#{key}=#{value} "
+          end
+          fact_vars << ";"
+          fact_vars
         end
 
         def remove_repo

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -36,6 +36,7 @@ remove_puppet_repo | false | remove copy of puppet repository and puppet configu
 hiera_eyaml | false | use hiera-eyaml to encrypt hiera data
 hiera_eyaml_key_remote_path | "/etc/puppet/secure/keys" | directory of hiera-eyaml keys on server
 hiera_eyaml_key_path  | "hiera_keys" | directory of hiera-eyaml keys on workstation
+facter_file | nil | yaml file of custom facter_files to be provided to the puppet-apply command
 
 ## Puppet Apply Configuring Provisioner Options
 


### PR DESCRIPTION
Allows user to set custom facter facts from a yaml file instead of
listing potentially multiple lines into the `custom_facts` array.

This can also be set per test suite to point to different fact files per
test suites.
