### PR TITLE
Regex fix when testing module in kitchen_root

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -563,7 +563,7 @@ module Kitchen
               module_target_path = File.join(sandbox_path, 'modules', module_name)
               FileUtils.mkdir_p(module_target_path)
               FileUtils.cp_r(
-                Dir.glob(File.join(config[:kitchen_root], '*')).reject { |entry| entry =~ /modules/ },
+                Dir.glob(File.join(config[:kitchen_root], '*')).reject { |entry| entry =~ /modules$/ },
                 module_target_path,
                 remove_destination: true
               )


### PR DESCRIPTION
First of all - thanks for the nice plugin!

This PR tries to solve the issue when developing a puppet module that resides in a parent directory named something with "modules", and instead of nuking the whole module we want to test only nuke the modules folder in kitchen_root (which I guess is what was intended?)
