### PR TITLE
Add rake gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@
 source 'https://rubygems.org'
 
 gem 'rubocop', '0.26.1', require: false
+gem 'rake', '>=10.2.0'


### PR DESCRIPTION
Ruby 1.9.3 requires rake inside the Gemfile to run "bundle exec rake"
This should fix travis-ci :)
