### PR TITLE
Add install_custom_facts provisioner option

### DIFF
--- a/kitchen-puppet.gemspec
+++ b/kitchen-puppet.gemspec
@@ -25,5 +25,4 @@ Puppet Provisioner for Test Kitchen
 Supports puppet apply, puppet agent, hiera, hiera-eyaml, custom facts, librarian-puppet
 
 EOF
-
 end

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -25,6 +25,7 @@ puppet_verbose| false| Extra information logging on puppet run
 puppet_noop| false| puppet runs in a no-op or dry-run mode
 update_package_repos| true| update OS repository metadata
 custom_facts| Hash.new | Hash to set the puppet facts before running puppet apply
+install_custom_facts| false | Install custom facts to yaml file at "/tmp/kitchen/facter/kitchen.yaml"
 chef_bootstrap_url |"https://www.getchef.com/chef/install.sh"| the chef (needed for busser to run tests)
 puppetfile_path | | Path to Puppetfile
 puppet_apply_command | nil | Overwrite the puppet apply command. Needs "sudo -E puppet apply" as a prefix. 


### PR DESCRIPTION
Allows user to install any specified custom facts to the test-node. This is useful if facter is ever ran after or during the initial 'puppet apply' to the node.

Currently, any custom facter facts that are specified are added as environment variables to the puppet_apply command. This ensures that any resources running the "facter" binary, or depending on facter running after that provisioning command will incorporate the new facter facts