### PR TITLE
Make sure wget is installed before downloading

### DIFF
--- a/lib/kitchen/provisioner/puppet_agent.rb
+++ b/lib/kitchen/provisioner/puppet_agent.rb
@@ -116,6 +116,7 @@ module Kitchen
             info("Installing puppet on #{puppet_platform}")
             <<-INSTALL
               if [ ! $(which puppet) ]; then
+                #{sudo('apt-get')} -y install wget
                 #{sudo('wget')} #{wget_proxy_parm} #{puppet_apt_repo}
                 #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                 #{update_packages_debian_cmd}
@@ -148,6 +149,7 @@ module Kitchen
                     #{update_packages_redhat_cmd}
                     #{sudo('yum')} -y install puppet#{puppet_redhat_version}
                   else
+                    #{sudo('apt-get')} -y install wget
                     #{sudo('wget')} #{wget_proxy_parm} #{puppet_apt_repo}
                     #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                     #{update_packages_debian_cmd}

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -170,6 +170,7 @@ module Kitchen
             info("Installing puppet on #{puppet_platform}")
             <<-INSTALL
               if [ ! $(which puppet) ]; then
+                #{sudo('apt-get')} -y install wget
                 #{sudo('wget')} #{wget_proxy_parm} #{puppet_apt_repo}
                 #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                 #{update_packages_debian_cmd}
@@ -206,6 +207,7 @@ module Kitchen
                     #{update_packages_redhat_cmd}
                     #{sudo_env('yum')} -y install puppet#{puppet_redhat_version}
                   else
+                    #{sudo('apt-get')} -y install wget
                     #{sudo('wget')} #{wget_proxy_parm} #{puppet_apt_repo}
                     #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                     #{update_packages_debian_cmd}


### PR DESCRIPTION
On some systems, most notably docker containers, wget might not be
installed. This will cause the wget command to fail. apt-get install
will then install puppet from the official debian repos. This was a
silent failure, has the user had to watch the output to notice something
was amiss.