### PR TITLE
Add ability to initialize /etc/puppet from git repository

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -56,6 +56,9 @@ module Kitchen
 
       default_config :puppet_apply_command, nil
 
+      default_config :puppet_git_init, nil
+      default_config :puppet_git_pr, nil
+
       default_config :http_proxy, nil
 
       default_config :hiera_data_remote_path, '/var/lib/hiera'
@@ -297,6 +300,32 @@ module Kitchen
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def prepare_command
         commands = []
+        if puppet_git_init
+          commands << [
+            sudo('rm -rf'), '/etc/puppet'
+          ].join(' ')
+
+          commands << [
+            sudo('git clone'), puppet_git_init, '/etc/puppet'
+          ].join(' ')
+        end
+
+        if puppet_git_pr
+          commands << [
+            sudo('git'), '--git-dir=/etc/puppet/.git/',
+                         'fetch -f',
+                         'origin',
+                         "pull/#{puppet_git_pr}/head:pr_#{puppet_git_pr}"
+          ].join(' ')
+
+          commands << [
+            sudo('git'), '--git-dir=/etc/puppet/.git/',
+                         '--work-tree=/etc/puppet/',
+                         'checkout',
+                         "pr_#{puppet_git_pr}"
+          ].join(' ')
+        end
+
         if puppet_config
           commands << [
             sudo('cp'),
@@ -424,6 +453,14 @@ module Kitchen
 
       def puppet_environment
         config[:puppet_environment]
+      end
+
+      def puppet_git_init
+        config[:puppet_git_init]
+      end
+
+      def puppet_git_pr
+        config[:puppet_git_pr]
       end
 
       def hiera_config

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -23,6 +23,8 @@ hiera_data_remote_path | "/var/lib/hiera" | Hiera data directory on server
 puppet_debug| false| Enable full debugging logging on puppet run
 puppet_verbose| false| Extra information logging on puppet run
 puppet_noop| false| puppet runs in a no-op or dry-run mode
+puppet_git_init | nil | initialize puppet from GIT repository, e.g. "git@github.com:example/puppet-repo.git"
+puppet_git_pr | nil | checkout specific Pull Request from repository specified in puppet_git_init, e.g. "324"
 update_package_repos| true| update OS repository metadata
 custom_facts| Hash.new | Hash to set the puppet facts before running puppet apply
 install_custom_facts| false | Install custom facts to yaml file at "/tmp/kitchen/facter/kitchen.yaml"


### PR DESCRIPTION
Our use case: apart from puppet code itself we need to deliver supporting testing facilities which is part of our puppet manifest git repo.

In future it can be extended to also use fully git based code within test vm for converge (instead of /tmp/kitchen)