### PR TITLE
Correct example in provisioner_options.md

### DIFF
--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -192,5 +192,6 @@ To override a setting at the suite-level, specify the setting name under the sui
 ```yaml
     suites:
      - name: default
-       manifest: foobar.pp
+       provisioner:
+         manifest: foobar.pp
 ```


### PR DESCRIPTION
As given, the example does not work, and requires the overriding settings to be inside a `provisioner` block.

A working example can be seen here: https://github.com/neillturner/kitchen-ansible#testing-multiple-playbooks