### PR TITLE
Puppet 2.7 support

### DIFF
--- a/lib/kitchen/provisioner/puppet_agent.rb
+++ b/lib/kitchen/provisioner/puppet_agent.rb
@@ -43,6 +43,7 @@ module Kitchen
       default_config :puppet_omnibus_url, nil
       default_config :puppet_omnibus_remote_path, '/opt/puppet'
       default_config :puppet_version, nil
+      default_config :facter_version, nil
       default_config :require_puppet_repo, true
       default_config :require_chef_for_busser, true
 
@@ -120,6 +121,7 @@ module Kitchen
                 #{sudo('wget')} #{wget_proxy_parm} #{puppet_apt_repo}
                 #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                 #{update_packages_debian_cmd}
+                #{sudo_env('apt-get')} -y install facter#{facter_debian_version}
                 #{sudo('apt-get')} -y install puppet-common#{puppet_debian_version}
                 #{sudo('apt-get')} -y install puppet#{puppet_debian_version}
               fi
@@ -153,6 +155,7 @@ module Kitchen
                     #{sudo('wget')} #{wget_proxy_parm} #{puppet_apt_repo}
                     #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                     #{update_packages_debian_cmd}
+                    #{sudo('apt-get')} -y install facter#{facter_debian_version}
                     #{sudo('apt-get')} -y install puppet-common#{puppet_debian_version}
                     #{sudo('apt-get')} -y install puppet#{puppet_debian_version}
                   fi
@@ -253,6 +256,10 @@ module Kitchen
 
       def puppet_debian_version
         config[:puppet_version] ? "=#{config[:puppet_version]}" : nil
+      end
+
+      def facter_debian_version
+        config[:facter_version] ? "=#{config[:facter_version]}" : nil
       end
 
       def puppet_redhat_version

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -44,6 +44,8 @@ module Kitchen
       default_config :puppet_apt_collections_repo, 'http://apt.puppetlabs.com/puppetlabs-release-pc1-wheezy.deb'
       default_config :puppet_coll_remote_path, '/opt/puppetlabs'
       default_config :puppet_version, nil
+      default_config :facter_version, nil
+      default_config :hiera_version, nil
       default_config :require_puppet_repo, true
       default_config :require_chef_for_busser, true
       default_config :resolve_with_librarian_puppet, true
@@ -162,8 +164,10 @@ module Kitchen
                 #{sudo('wget')} #{wget_proxy_parm} #{puppet_apt_repo}
                 #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                 #{update_packages_debian_cmd}
+                #{sudo_env('apt-get')} -y install facter#{facter_debian_version}
                 #{sudo_env('apt-get')} -y install puppet-common#{puppet_debian_version}
                 #{sudo_env('apt-get')} -y install puppet#{puppet_debian_version}
+                #{sudo_env('apt-get')} -y install hiera-puppet#{puppet_hiera_debian_version}
               fi
               #{install_eyaml}
               #{install_deep_merge}
@@ -193,8 +197,10 @@ module Kitchen
                     #{sudo('wget')} #{wget_proxy_parm} #{puppet_apt_repo}
                     #{sudo('dpkg')} -i #{puppet_apt_repo_file}
                     #{update_packages_debian_cmd}
+                    #{sudo_env('apt-get')} -y install facter#{facter_debian_version}
                     #{sudo_env('apt-get')} -y install puppet-common#{puppet_debian_version}
                     #{sudo_env('apt-get')} -y install puppet#{puppet_debian_version}
+                    #{sudo_env('apt-get')} -y install hiera-puppet#{puppet_hiera_debian_version}
                   fi
                 fi
               fi
@@ -592,6 +598,14 @@ module Kitchen
 
       def puppet_debian_version
         config[:puppet_version] ? "=#{config[:puppet_version]}" : nil
+      end
+
+      def facter_debian_version
+        config[:facter_version] ? "=#{config[:facter_version]}" : nil
+      end
+
+      def puppet_hiera_debian_version
+        config[:hiera_version] ? "=#{config[:hiera_version]}" : nil
       end
 
       def puppet_redhat_version

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -613,7 +613,11 @@ module Kitchen
       end
 
       def puppet_environment_flag
-        config[:puppet_environment] ? "--environment=#{config[:puppet_environment]} --environmentpath=#{puppet_dir}" : nil
+        if config[:puppet_version] =~ /^2/
+          config[:puppet_environment] ? "--environment=#{config[:puppet_environment]}" : nil
+        else
+          config[:puppet_environment] ? "--environment=#{config[:puppet_environment]} --environmentpath=#{puppet_dir}" : nil
+        end
       end
 
       def puppet_manifestdir

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -4,6 +4,8 @@
 key | default value | Notes
 ----|---------------|--------
 puppet_version | "latest"| desired version, affects apt installs.
+facter_version | "latest"| desired version, affects apt installs.
+hiera_version | "latest"| desired version, affects apt installs.
 puppet_platform | naively tries to determine | OS platform of server
 require_puppet_repo | true | Set if using a puppet install from yum or apt repo
 puppet_apt_repo | "http://apt.puppetlabs.com/puppetlabs-release-precise.deb"| apt repo
@@ -113,6 +115,7 @@ no idea why Puppet versioned their repository with a trailing
 key | default value | Notes
 ----|---------------|--------
 puppet_version | "latest"| desired version, affects apt installs.
+facter_version | "latest"| desired version, affects apt installs.
 puppet_platform | naively tries to determine | OS platform of server
 require_puppet_repo | true | Set if using a puppet install from yum or apt repo
 puppet_apt_repo | "http://apt.puppetlabs.com/puppetlabs-release-precise.deb"| apt repo


### PR DESCRIPTION
I know that puppet 2.7 is deprecated, however one sometimes finds themselves working in legacy environments that are still using 2.7.

In order to move to puppet 3+ we need to write tests for puppet 2.7 to ensure that we don't break the legacy systems before they are able to upgrade, ensuring we support both 2.7 and 3+.

This PR adds support for puppet 2.7. Due to the dependencies on debian for the puppetlabs packages we need to be able to specify facter and hiera package versions to install.