### PR TITLE
Ensure hiera config file is copied to sandbox

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -809,7 +809,7 @@ module Kitchen
         info('Preparing hiera')
         debug("Using hiera from #{hiera_config}")
 
-        FileUtils.cp_r(hiera_config, File.join(sandbox_path, 'hiera.yaml'))
+        FileUtils.cp(File.join(hiera_config, 'hiera.yaml'), File.join(sandbox_path, 'hiera.yaml'))
       end
 
       def prepare_fileserver_config


### PR DESCRIPTION
The hiera_config variable is a path, this causes a directory called
hiera.yaml to be created in the sandbox with the hiera.yaml file inside
it. Which then causes puppet apply to fail due to hiera.yaml being a
directory.