### PR TITLE
Fix suite override example for puppet apply

### DIFF
--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -92,7 +92,8 @@ To override a setting at the suite-level, specify the setting name under the sui
 ```yaml
     suites:
      - name: default
-       manifest: foobar.pp
+       provisioner:
+         manifest: foobar.pp
 ```
 ### Per-suite Structure
 


### PR DESCRIPTION
The other patch missed the apply section.