### PR TITLE
Don't include spec and pkg subdirectories to the module

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -828,7 +828,7 @@ module Kitchen
         module_target_path = File.join(sandbox_path, 'modules', module_name)
         FileUtils.mkdir_p(module_target_path)
         FileUtils.cp_r(
-          Dir.glob(File.join(config[:kitchen_root], '*')).reject { |entry| entry =~ /modules$/ },
+          Dir.glob(File.join(config[:kitchen_root], '*')).reject { |entry| entry =~ /modules$|spec$|pkg$/ },
           module_target_path,
           remove_destination: true
         )


### PR DESCRIPTION
Hi,

I've patched copy_self_as_module to not include 'spec' and 'pkg' module subdirectories of the module being developed. The main reason for this change is smother interoperability with puppetlabs_spec_helper which creates symlinks in spec/fixtures/modules that than break test kitchen.

Please include my change in next kitchen-puppet release.

Petr.