### PR TITLE
Fix rubocop issues

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -33,7 +33,7 @@ module Kitchen
   end
 
   module Configurable
-    def platform_name(*)
+    def platform_name
       instance.platform.name
     end
   end
@@ -132,9 +132,7 @@ module Kitchen
       default_config :puppet_debug, false
       default_config :puppet_verbose, false
       default_config :puppet_noop, false
-      default_config :platform do |provisioner|
-        provisioner.platform_name('')
-      end
+      default_config :platform, &:platform_name
       default_config :update_package_repos, true
       default_config :remove_puppet_repo, false
       default_config :custom_facts, {}

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -5,7 +5,6 @@ key | default value | Notes
 ----|---------------|--------
 puppet_version | "latest"| desired version, affects apt installs.
 facter_version | "latest"| desired version, affects apt installs.
-platform | platform_name kitchen.yml parameter | OS platform of server
 hiera_version | "latest"| desired version, affects apt installs.
 install_hiera | false | Installs `hiera-puppet` package. Not needed for puppet > 3.x.x
 require_puppet_repo | true | Set if using a puppet install from yum or apt repo


### PR DESCRIPTION
Instead of changing the method arguments passed to a function, actually
call the function properly. This keeps the code functioning in exactly
the same fashion as it was previously, yet updates style to conform to
rubocop's update of the SymbolProc cop.

--------
Setting the `platform` configuration option _will_ break
things. Provisioner options are generally set at the global level, and
if a developer has multiple suites of differing platforms, this will
cause things to break. By inheriting the `Configurable` module from
test-kitchen we are able to read the platform name for each test suite's
platform correctly. This will even read the platform correctly if
`.kitchen.yml` only has one test suite but multiple platforms defined.

I can't think of a solid case where the `platform` configuration option
would need to be set specifically different from the default.
