### PR TITLE
Lock Gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'rubocop', '>=0.26.1'
-gem 'rake', '>=10.2.0'
-gem 'rspec'
-gem 'simplecov'
+gem 'rubocop', '~> 0.34'
+gem 'rake', '~> 10.4.2'
+gem 'rspec', '~> 3.3.0'
+gem 'simplecov', '~> 0.10'


### PR DESCRIPTION
Lock Gem versions, forcing explicit upgrade of gem versions.

Prevents issues found on previous PR's where a new version of a gem is
released before the PR is merged into master.