### PR TITLE
Include documented dirs in copy self as module

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -906,7 +906,7 @@ module Kitchen
         module_target_path = File.join(sandbox_path, 'modules', module_name)
         FileUtils.mkdir_p(module_target_path)
         FileUtils.cp_r(
-          Dir.glob(File.join(config[:kitchen_root], '*')).reject { |entry| entry =~ /modules$|spec$|pkg$/ },
+          Dir.glob(File.join(config[:kitchen_root], '*')).select { |entry| entry =~ /manifests$|files$|templates$|lib$|facts\.d$|examples$|data$/ },
           module_target_path,
           remove_destination: true
         )


### PR DESCRIPTION
Similar to MR #66, this merge changes the behavior when copying self as a module. I had found that the current logic was discarding either the pkg, module, and spec dirs. This was such a surprise when I had a .bundle dir for modules dependencies.

Instead of removing directories, I have changed the behavior to only include dirs mentioned at https://docs.puppetlabs.com/puppet/latest/reference/modules_fundamentals.html#module-layout (less spec), and included a data dir so it will work with modules that support data-bindings. 
