### PR TITLE
Ignore /bundle directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Gemfile.lock
 
 *.rbc
 .bundle
+bundle
 .config
 coverage
 InstalledFiles

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - vendor/**
+    - bundle/**/*
 
 Documentation:
   Enabled: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,4 +4,5 @@ require 'simplecov'
 # Filter out our tests from code coverage
 SimpleCov.start do
   add_filter '/spec/'
+  add_filter '/bundle/'
 end


### PR DESCRIPTION
This is handy when using `bundle install --standalone`

* .gitignore
* rubocop
* coverage