### PR TITLE
Add Hiera Package Name Configuration

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -53,6 +53,7 @@ module Kitchen
       default_config :facter_version, nil
       default_config :hiera_version, nil
       default_config :install_hiera, false
+      default_config :hiera_package, 'hiera-puppet'
       default_config :require_puppet_repo, true
       default_config :require_chef_for_busser, true
       default_config :resolve_with_librarian_puppet, true
@@ -331,8 +332,12 @@ module Kitchen
       def install_hiera
         return unless config[:install_hiera]
         <<-INSTALL
-          #{sudo_env('apt-get')} -y install hiera-puppet#{puppet_hiera_debian_version}
+        #{sudo_env('apt-get')} -y install #{hiera_package}
         INSTALL
+      end
+
+      def hiera_package
+        "#{config[:hiera_package]}#{puppet_hiera_debian_version}"
       end
 
       # /bin/wget -P /etc/pki/rpm-gpg/ http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -8,6 +8,7 @@ facter_version | "latest"| desired version, affects apt installs.
 platform | platform_name kitchen.yml parameter | OS platform of server
 hiera_version | "latest"| desired version, affects apt installs.
 install_hiera | false | Installs `hiera-puppet` package. Not needed for puppet > 3.x.x
+hiera_package | 'hiera-puppet' | Only used if `install_hiera` is set
 require_puppet_repo | true | Set if using a puppet install from yum or apt repo
 puppet_apt_repo | "http://apt.puppetlabs.com/puppetlabs-release-precise.deb"| apt repo
 puppet_yum_repo | "https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm"| yum repo

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -240,6 +240,14 @@ describe Kitchen::Provisioner::PuppetApply do
       it 'should set hiera deep merge to false' do
         expect(provisioner[:hiera_deep_merge]).to eq(false)
       end
+
+      it 'should not install the hiera package' do
+        expect(provisioner[:install_hiera]).to eq(false)
+      end
+
+      it 'should keep default hiera package name' do
+        expect(provisioner[:hiera_package]).to eq('hiera-puppet')
+      end
     end
 
     context 'non-default sets' do
@@ -494,6 +502,11 @@ describe Kitchen::Provisioner::PuppetApply do
       it 'should set spec files remote path' do
         config[:spec_files_remote_path] = '/etc/puppet/spec'
         expect(provisioner[:spec_files_remote_path]).to eq('/etc/puppet/spec')
+      end
+
+      it 'should set hiera package name' do
+        config[:hiera_package] = 'hiera'
+        expect(provisioner[:hiera_package]).to eq('hiera')
       end
     end
   end


### PR DESCRIPTION
Adds Hiera Package Name configuration for installing hiera from a different package name than `hiera-puppet`