### PR TITLE
ManifestDir is Deprecated in Puppet4

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -676,7 +676,7 @@ module Kitchen
       def puppet_manifestdir
         return nil if config[:require_puppet_collections]
         return nil if config[:puppet_environment]
-        bash_vars = "export MANIFESTDIR=#{File.join(config[:root_path], 'manifests')};"
+        bash_vars = "export MANIFESTDIR='#{File.join(config[:root_path], 'manifests')}';"
         debug(bash_vars)
         bash_vars
       end

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -674,6 +674,7 @@ module Kitchen
       end
 
       def puppet_manifestdir
+        return nil if config[:require_puppet_collections]
         config[:puppet_environment] ? nil : "--manifestdir=#{File.join(config[:root_path], 'manifests')}"
       end
 

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -523,11 +523,11 @@ module Kitchen
             facterlib,
             custom_facts,
             facter_facts,
+            puppet_manifestdir,
             puppet_cmd,
             'apply',
             File.join(config[:root_path], 'manifests', manifest),
             "--modulepath=#{File.join(config[:root_path], 'modules')}",
-            puppet_manifestdir,
             "--fileserverconfig=#{File.join(config[:root_path], 'fileserver.conf')}",
             puppet_environment_flag,
             puppet_noop_flag,
@@ -675,7 +675,10 @@ module Kitchen
 
       def puppet_manifestdir
         return nil if config[:require_puppet_collections]
-        config[:puppet_environment] ? nil : "--manifestdir=#{File.join(config[:root_path], 'manifests')}"
+        return nil if config[:puppet_environment]
+        bash_vars = "export MANIFESTDIR=#{File.join(config[:root_path], 'manifests')};"
+        debug(bash_vars)
+        bash_vars
       end
 
       def puppet_noop_flag

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -545,5 +545,11 @@ CUSTOM_COMMAND
       config[:facterlib] = '/etc/puppet/facter'
       expect(provisioner.run_command).to include("export FACTERLIB='/etc/puppet/facter';")
     end
+
+    it 'exports MANIFESTDIR when not using puppet collections or environments' do
+      config[:require_puppet_collections] = false
+      config[:puppet_environment] = nil
+      expect(provisioner.run_command).to include("export MANIFESTDIR='/tmp/kitchen/manifests';")
+    end
   end
 end


### PR DESCRIPTION
if require_puppet_collections is specified don't specify the manifest_dir. My understanding is you can only install puppet v4 via collections so this should work. please review and merge if you agree with this change. @grubernaut  @ytsarev