### PR TITLE
Fix typo with wget https proxy attribute

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -831,7 +831,7 @@ module Kitchen
 
       def wget_proxy_parm
         p = http_proxy ? "-e http_proxy=#{http_proxy}" : nil
-        s = https_proxy ? "-e http_proxy=#{http_proxy}" : nil
+        s = https_proxy ? "-e https_proxy=#{https_proxy}" : nil
         p || s ? "-e use_proxy=yes #{p} #{s}" : nil
       end
 


### PR DESCRIPTION
When behind a corporate proxy and using http proxy parameters, wget is failing because https_proxy was not being set properly