### PR TITLE
Expose detailed exit codes during puppet apply

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -63,6 +63,7 @@ module Kitchen
       default_config :chef_bootstrap_url, 'https://www.getchef.com/chef/install.sh'
       default_config :puppet_logdest, nil
       default_config :custom_install_command, nil
+      default_config :puppet_whitelist_exit_code, nil
 
       default_config :puppet_apply_command, nil
 
@@ -417,6 +418,10 @@ module Kitchen
         return if sandbox_path.nil?
         debug("Cleaning up local sandbox in #{sandbox_path}")
         FileUtils.rmtree(sandbox_path)
+        if remove_repo
+          debug("Cleaning up remote sandbox in /tmp/kitchen")
+          remote_command remove_repo
+        end
       end
 
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
@@ -537,7 +542,7 @@ module Kitchen
             puppet_verbose_flag,
             puppet_debug_flag,
             puppet_logdest_flag,
-            remove_repo
+            puppet_whitelist_exit_code
           ].join(' ')
           info("Going to invoke puppet apply with: #{result}")
           result
@@ -775,7 +780,11 @@ module Kitchen
       end
 
       def remove_repo
-        remove_puppet_repo ? "; #{sudo('rm')} -rf /tmp/kitchen #{hiera_data_remote_path} #{hiera_eyaml_key_remote_path} #{puppet_dir}/* " : nil
+        remove_puppet_repo ? "#{sudo('rm')} -rf /tmp/kitchen #{hiera_data_remote_path} #{hiera_eyaml_key_remote_path} #{puppet_dir}/* " : nil
+      end
+
+      def puppet_whitelist_exit_code
+        config[:puppet_whitelist_exit_code] ? "; [ $? -eq #{config[:puppet_whitelist_exit_code]} ] && exit 0" : nil
       end
 
       def puppet_apt_repo

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -20,7 +20,7 @@ _for RH/Centos7 change to_ | "https://yum.puppetlabs.com/puppetlabs-release-pc1-
 puppet_apt_collections_repo | "http://apt.puppetlabs.com/puppetlabs-release-pc1-wheezy.deb" | apt collections repo
 _for Ubuntu15 change to_ | "http://apt.puppetlabs.com/puppetlabs-release-pc1-jessie.deb" |
 puppet_coll_remote_path | "/opt/puppetlabs" | Server Installation location of a puppet collections install.
-puppet_detailed_exitcodes | nil | Provide transaction information via exit codes.
+puppet_detailed_exitcodes | nil | Provide transaction information via exit codes. See `--detailed-exitcodes` section of `puppet help apply`
 manifests_path | | puppet repo manifests directory
 manifest | 'site.pp' | manifest for puppet apply to run
 modules_path | | puppet repo manifests directory
@@ -56,6 +56,7 @@ https_proxy | nil | use https proxy when installing puppet, packages and running
 puppet_logdest | nil | _Array_ of log destinations. Include 'console' if wanted
 custom_options | | custom options to add to puppet apply command.
 custom_install_command | nil | Custom shell command to be used at install stage. Can be multiline. See examples below.
+puppet_whitelist_exit_code | nil | Whitelist exit code expected from puppet run. Intended to be used together with `puppet_detailed_exitcodes`.
 
 
 ## Puppet Apply Configuring Provisioner Options


### PR DESCRIPTION
Otherwise `kitchen converge` can return 0 exit status
even with Errored puppet run