### PR TITLE
Provide ability to whitelist puppet exit code.

### DIFF
--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -20,7 +20,7 @@ _for RH/Centos7 change to_ | "https://yum.puppetlabs.com/puppetlabs-release-pc1-
 puppet_apt_collections_repo | "http://apt.puppetlabs.com/puppetlabs-release-pc1-wheezy.deb" | apt collections repo
 _for Ubuntu15 change to_ | "http://apt.puppetlabs.com/puppetlabs-release-pc1-jessie.deb" |
 puppet_coll_remote_path | "/opt/puppetlabs" | Server Installation location of a puppet collections install.
-puppet_detailed_exitcodes | nil | Provide transaction information via exit codes.
+puppet_detailed_exitcodes | nil | Provide transaction information via exit codes. See `--detailed-exitcodes` section of `puppet help apply`
 manifests_path | | puppet repo manifests directory
 manifest | 'site.pp' | manifest for puppet apply to run
 modules_path | | puppet repo manifests directory
@@ -56,6 +56,7 @@ https_proxy | nil | use https proxy when installing puppet, packages and running
 puppet_logdest | nil | _Array_ of log destinations. Include 'console' if wanted
 custom_options | | custom options to add to puppet apply command.
 custom_install_command | nil | Custom shell command to be used at install stage. Can be multiline. See examples below.
+puppet_whitelist_exit_code | nil | Whitelist exit code expected from puppet run. Intended to be used together with `puppet_detailed_exitcodes`.
 
 
 ## Puppet Apply Configuring Provisioner Options

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -567,5 +567,10 @@ CUSTOM_COMMAND
       config[:custom_options] = '--no-stringify_facts'
       expect(provisioner.run_command).to include('--no-stringify_facts')
     end
+
+    it 'whitelists exit code' do
+      config[:puppet_whitelist_exit_code] = '2'
+      expect(provisioner.run_command).to match(/; \[ \$\? -eq 2 \] && exit 0$/)
+    end
   end
 end


### PR DESCRIPTION
* New puppet_whitelist_exit_code configuration option
* Move remove_repo to cleanup section so it does not hide puppet exit
  code
* Relevant documentation