### PR TITLE
Update net-ssh gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - "1.9.3"
   - "2.0.0"
   - "2.1"
+  - "2.2"
 
 sudo: required
 services:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'rubocop', '~> 0.34'
 gem 'rake', '~> 10.4.2'
 gem 'rspec', '~> 3.3.0'
 gem 'simplecov', '~> 0.10'
-gem 'net-ssh', '~> 2.0'
 
 group :integration do
   gem 'test-kitchen'

--- a/kitchen-puppet.gemspec
+++ b/kitchen-puppet.gemspec
@@ -17,7 +17,11 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.rubyforge_project = '[none]'
   s.add_dependency 'test-kitchen', '~> 1.4'
-  s.add_dependency 'net-ssh', '~> 2.0'
+  if RUBY_VERSION >= '2.0'
+    s.add_dependency 'net-ssh', '~> 3.0.2'
+  else
+    s.add_dependency 'net-ssh', '~> 2.9.4'
+  end
   s.description = <<-EOF
 == DESCRIPTION:
 


### PR DESCRIPTION
Update net-ssh gem to properly working gem version.

v2.9.4 currently throws the following warning:

```
net-ssh-2.9.4/lib/net/ssh/transport/session.rb:67:in `initialize':
Object#timeout is deprecated, use Timeout.timeout instead.
```