### PR TITLE
add puppet v3 support on amazon linux

### DIFF
--- a/lib/kitchen/provisioner/puppet_agent.rb
+++ b/lib/kitchen/provisioner/puppet_agent.rb
@@ -260,7 +260,11 @@ module Kitchen
       end
 
       def puppet_redhat_version
-        config[:puppet_version] ? "-#{config[:puppet_version]}" : nil
+        if puppet_platform == 'amazon'
+          config[:puppet_version]
+        else
+          config[:puppet_version] ? "-#{config[:puppet_version]}" : nil
+        end
       end
 
       def puppet_noop_flag

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -678,7 +678,11 @@ module Kitchen
       end
 
       def puppet_redhat_version
-        config[:puppet_version] ? "-#{config[:puppet_version]}" : nil
+        if puppet_platform == 'amazon'
+          config[:puppet_version]
+        else
+          config[:puppet_version] ? "-#{config[:puppet_version]}" : nil
+        end
       end
 
       def puppet_environment_flag


### PR DESCRIPTION
fixes #114 by adding an additional conditional check when setting the redhat package version number.