### PR TITLE
allow puppet_cmd to be without sudo

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -155,6 +155,7 @@ module Kitchen
       end
 
       default_config :hiera_deep_merge, false
+      default_config :puppet_no_sudo, false
 
       def calculate_path(path, type = :directory)
         base = config[:test_base_path]
@@ -678,10 +679,15 @@ module Kitchen
       end
 
       def puppet_cmd
+        puppet_bin = 'puppet'
         if config[:require_puppet_collections]
-          sudo_env("#{config[:puppet_coll_remote_path]}/bin/puppet")
+          puppet_bin = "#{config[:puppet_coll_remote_path]}/bin/puppet"
+        end
+
+        if config[:puppet_no_sudo]
+          puppet_bin
         else
-          sudo_env('puppet')
+          sudo_env(puppet_bin)
         end
       end
 

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -248,6 +248,10 @@ describe Kitchen::Provisioner::PuppetApply do
       it 'should keep default hiera package name' do
         expect(provisioner[:hiera_package]).to eq('hiera-puppet')
       end
+
+      it 'should run puppet with sudo' do
+        expect(provisioner[:puppet_no_sudo]).to eq(false)
+      end
     end
 
     context 'non-default sets' do
@@ -571,6 +575,16 @@ CUSTOM_COMMAND
     it 'whitelists exit code' do
       config[:puppet_whitelist_exit_code] = '2'
       expect(provisioner.run_command).to match(/; \[ \$\? -eq 2 \] && exit 0$/)
+    end
+
+    it 'can run without sudo' do
+      config[:puppet_no_sudo] = true
+      expect(provisioner.run_command).not_to include('sudo -E')
+    end
+
+    it 'can run with sudo' do
+      config[:puppet_no_sudo] = false
+      expect(provisioner.run_command).to include('sudo -E')
     end
   end
 end


### PR DESCRIPTION
When running with the kitchen-docker driver. I ran into a case where I don't need to run puppet with sudo.