### PR TITLE
configure what is excluded when copying module

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Documentation:
 AlignParameters:
   Enabled: true
 Encoding:
-  Enabled: true
+  Enabled: false
 HashSyntax:
   Enabled: true
 LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   Exclude:
-    - vendor/**
-    - bundle/**/*
+    - 'vendor/**/*'
+    - 'bundle/**/*'
 
 Documentation:
   Enabled: false

--- a/lib/kitchen/provisioner/puppet/librarian.rb
+++ b/lib/kitchen/provisioner/puppet/librarian.rb
@@ -44,7 +44,9 @@ module Kitchen
           debug("Using Puppetfile from #{puppetfile}")
 
           env = ::Librarian::Puppet::Environment.new(
-            project_path: File.dirname(puppetfile))
+            project_path: File.dirname(puppetfile)
+          )
+
           env.config_db.local['path'] = path
           ::Librarian::Action::Resolve.new(env).run
           ::Librarian::Action::Install.new(env).run

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -77,6 +77,7 @@ module Kitchen
       default_config :http_proxy, nil
       default_config :https_proxy, nil
 
+      default_config :ignore_paths_from_root, []
       default_config :hiera_data_remote_path, '/var/lib/hiera'
       default_config :manifest, 'site.pp'
 
@@ -1006,8 +1007,11 @@ module Kitchen
         return unless module_name
         module_target_path = File.join(sandbox_path, 'modules', module_name)
         FileUtils.mkdir_p(module_target_path)
+
+        excluded_paths = ['modules', 'spec', 'pkg'] + config[:ignored_paths_from_root]
+
         FileUtils.cp_r(
-          Dir.glob(File.join(config[:kitchen_root], '*')).reject { |entry| entry =~ /modules$|spec$|pkg$/ },
+          Dir.glob(File.join(config[:kitchen_root], '*')).reject { |entry| entry =~ /#{excluded_paths.join('$|')}$/ },
           module_target_path,
           remove_destination: true
         )

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -467,18 +467,21 @@ module Kitchen
         end
 
         if puppet_git_pr
-          commands << [sudo('git'),
-                       '--git-dir=/etc/puppet/.git/',
-                       'fetch -f',
-                       'origin',
-                       "pull/#{puppet_git_pr}/head:pr_#{puppet_git_pr}"
-                      ].join(' ')
+          commands << [
+            sudo('git'),
+            '--git-dir=/etc/puppet/.git/',
+            'fetch -f',
+            'origin',
+            "pull/#{puppet_git_pr}/head:pr_#{puppet_git_pr}"
+          ].join(' ')
 
-          commands << [sudo('git'), '--git-dir=/etc/puppet/.git/',
-                       '--work-tree=/etc/puppet/',
-                       'checkout',
-                       "pr_#{puppet_git_pr}"
-                      ].join(' ')
+          commands << [
+            sudo('git'),
+            '--git-dir=/etc/puppet/.git/',
+            '--work-tree=/etc/puppet/',
+            'checkout',
+            "pr_#{puppet_git_pr}"
+          ].join(' ')
         end
 
         if puppet_config
@@ -1008,7 +1011,7 @@ module Kitchen
         module_target_path = File.join(sandbox_path, 'modules', module_name)
         FileUtils.mkdir_p(module_target_path)
 
-        excluded_paths = ['modules', 'spec', 'pkg'] + config[:ignored_paths_from_root]
+        excluded_paths = %w(modules spec pkg) + config[:ignored_paths_from_root]
 
         FileUtils.cp_r(
           Dir.glob(File.join(config[:kitchen_root], '*')).reject { |entry| entry =~ /#{excluded_paths.join('$|')}$/ },

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -77,7 +77,7 @@ module Kitchen
       default_config :http_proxy, nil
       default_config :https_proxy, nil
 
-      default_config :ignore_paths_from_root, []
+      default_config :ignored_paths_from_root, []
       default_config :hiera_data_remote_path, '/var/lib/hiera'
       default_config :manifest, 'site.pp'
 

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -145,8 +145,8 @@ describe Kitchen::Provisioner::PuppetApply do
         expect(provisioner[:manifests_path]).to eq(nil)
       end
 
-      it 'Should not ignore path when copying the module under test' do
-        expect(provisioner[:ignore_paths_from_root]).to eq([])
+      it 'Should not ignore additional paths when copying the module under test' do
+        expect(provisioner[:ignored_paths_from_root]).to eq([])
       end
 
       it 'Should find files path' do

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -145,6 +145,10 @@ describe Kitchen::Provisioner::PuppetApply do
         expect(provisioner[:manifests_path]).to eq(nil)
       end
 
+      it 'Should not ignore path when copying the module under test' do
+        expect(provisioner[:ignore_paths_from_root]).to eq([])
+      end
+
       it 'Should find files path' do
         expect(provisioner[:files_path]).to eq('files')
       end


### PR DESCRIPTION
Where I work we have a convention of installing all bundled gems at vendor/bundle. This can make the process of copying the module under test into the sandbox a really long one.

Used like:
```yaml
---
provisioner:
  name: puppet_apply
  excluded_paths_from_module:
    - '/vendor'
```