### PR TITLE
Add some windows support to Puppet Apply

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -837,7 +837,7 @@ module Kitchen
       def puppet_whitelist_exit_code
         return "; exit $LASTEXITCODE" if config[:puppet_whitelist_exit_code].nil? && powershell_shell?
         return nil if config[:puppet_whitelist_exit_code].nil?
-        return "; if(@(#{config[:puppet_whitelist_exit_code].join(', ')}) -contains $LASTEXITCODE) {exit 0} else {exit $LASTEXITCODE} " if powershell_shell?
+        return "; if(@(#{[config[:puppet_whitelist_exit_code]].join(', ')}) -contains $LASTEXITCODE) {exit 0} else {exit $LASTEXITCODE}" if powershell_shell?
         "; [ $? -eq #{config[:puppet_whitelist_exit_code]} ] && exit 0"
       end
 

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -743,7 +743,7 @@ module Kitchen
       end
 
       def puppet_cmd
-        puppet_bin = powershell_shell? ? 'C:\Program Files\Puppet Labs\Puppet\bin\puppet' : 'puppet'
+        puppet_bin = powershell_shell? ? '& "C:\Program Files\Puppet Labs\Puppet\bin\puppet"' : 'puppet'
         if config[:require_puppet_collections]
           puppet_bin = "#{config[:puppet_coll_remote_path]}/bin/puppet"
         end

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -839,10 +839,15 @@ module Kitchen
       def custom_facts
         return nil if config[:custom_facts].none?
         return nil if config[:install_custom_facts]
-        bash_vars = config[:custom_facts].map { |k, v| "FACTER_#{k}=#{v}" }.join(' ')
-        bash_vars = "export #{bash_vars};"
-        debug(bash_vars)
-        bash_vars
+        if powershell_shell?
+          environment_vars = config[:custom_facts].map { |k, v| "$env:FACTER_#{k}='#{v}'" }.join('; ')
+          environment_vars = "#{environment_vars};"
+        else
+          environment_vars = config[:custom_facts].map { |k, v| "FACTER_#{k}=#{v}" }.join(' ')
+          environment_vars = "export #{environment_vars};"
+        end
+        debug(environment_vars)
+        environment_vars
       end
 
       def puppet_detailed_exitcodes_flag

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -714,6 +714,7 @@ module Kitchen
         if config[:require_puppet_collections]
           sudo_env("#{config[:puppet_coll_remote_path]}/bin/puppet")
         else
+          return sudo_env('$env:Path += ";C:\Program Files\Puppet Labs\Puppet\bin"; puppet') if powershell_shell?
           sudo_env('puppet')
         end
       end

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -624,9 +624,6 @@ module Kitchen
       end
 
       def manifest
-          info("LBENNETT test")
-          info(config[:manifest])
-          info(diagnose)
         config[:manifest]
       end
 

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -472,9 +472,9 @@ module Kitchen
           "#{spec_files_remote_path}",
           "#{puppet_dir}/fileserver.conf"]
         todelete += File.join(puppet_dir, config[:puppet_environment]) if config[:puppet_environment]
-        cmd = "#{get_rm_command_paths(todelete)};"
+        cmd = "#{sudo(get_rm_command_paths(todelete))};"
         cmd += " #{get_mkdir_command} #{config[:root_path]};"
-        cmd += " #{get_mkdir_command} #{puppet_dir}"
+        cmd += " #{sudo(get_mkdir_command)} #{puppet_dir}"
         debug(cmd)
         cmd
       end
@@ -1166,12 +1166,12 @@ module Kitchen
 
       def get_rm_command
         return 'rm -force -recurse' if powershell_shell?
-        return "#{sudo('rm')} -rf"
+        return 'rm -rf'
       end
 
       def get_mkdir_command
         return 'mkdir -force -path' if powershell_shell?
-        return "#{sudo('mkdir')} -p"
+        return 'mkdir -p'
       end
 
       def get_rm_command_paths(paths)

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -546,11 +546,9 @@ module Kitchen
         end
 
         if hiera_config
-          if !powershell_shell?
-            commands << [
-              sudo(get_cp_command), File.join(config[:root_path], 'hiera.yaml'), '/etc/'
-            ].join(' ')
-          end
+          commands << [
+            sudo(get_cp_command), File.join(config[:root_path], 'hiera.yaml'), '/etc/'
+          ].join(' ')
 
           commands << [
             sudo(get_cp_command), File.join(config[:root_path], 'hiera.yaml'), hiera_config_dir

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -231,11 +231,6 @@ module Kitchen
                   Exit 1
               }
 
-              if($env:Path -notcontains 'C:\\Program Files\\Puppet Labs\\Puppet\\bin' ) {
-                $env:Path += ';C:\\Program Files\\Puppet Labs\\Puppet\\bin'
-                [Environment]::SetEnvironmentVariable('Path', $env:Path, 'Machine')
-              }
-
               #{install_busser}
             INSTALL
           else

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -835,10 +835,13 @@ module Kitchen
       end
 
       def puppet_whitelist_exit_code
-        return "; exit $LASTEXITCODE" if config[:puppet_whitelist_exit_code].nil? && powershell_shell?
-        return nil if config[:puppet_whitelist_exit_code].nil?
-        return "; if(@(#{[config[:puppet_whitelist_exit_code]].join(', ')}) -contains $LASTEXITCODE) {exit 0} else {exit $LASTEXITCODE}" if powershell_shell?
-        "; [ $? -eq #{config[:puppet_whitelist_exit_code]} ] && exit 0"
+        if config[:puppet_whitelist_exit_code].nil?
+          return powershell_shell? ? "; exit $LASTEXITCODE" : nil
+        else
+          return powershell_shell? ?
+            "; if(@(#{[config[:puppet_whitelist_exit_code]].join(', ')}) -contains $LASTEXITCODE) {exit 0} else {exit $LASTEXITCODE}" :
+            "; [ $? -eq #{config[:puppet_whitelist_exit_code]} ] && exit 0"
+        end
       end
 
       def puppet_apt_repo

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -429,6 +429,7 @@ module Kitchen
       end
 
       def init_command
+        return
         dirs = %w(modules manifests files hiera hiera.yaml facter spec)
                .map { |dir| File.join(config[:root_path], dir) }.join(' ')
         cmd = "#{sudo('rm')} -rf #{dirs} #{hiera_data_remote_path} \

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -253,14 +253,6 @@ module Kitchen
         end
       end
 
-      def install_command_posh
-        install_command
-      end
-
-      def init_command_posh
-
-      end
-
       def install_command_collections
         case puppet_platform
         when 'debian', 'ubuntu'

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -437,7 +437,6 @@ module Kitchen
       end
 
       def init_command
-        # TODO: the easiest way is probably to make this full .ps1 / .sh scripts ?
         todelete = %w(modules manifests files hiera hiera.yaml facter spec)
                .map { |dir| File.join(config[:root_path], dir) }
         todelete += [hiera_data_remote_path,

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -837,7 +837,7 @@ module Kitchen
       def puppet_whitelist_exit_code
         return "; exit $LASTEXITCODE" if config[:puppet_whitelist_exit_code].nil? && powershell_shell?
         return nil if config[:puppet_whitelist_exit_code].nil?
-        return "; exit ($LASTEXITCODE -ne #{config[:puppet_whitelist_exit_code]})" if powershell_shell?
+        return "; if(@(#{config[:puppet_whitelist_exit_code].join(', ')}) -contains $LASTEXITCODE) {exit 0} else {exit $LASTEXITCODE} " if powershell_shell?
         "; [ $? -eq #{config[:puppet_whitelist_exit_code]} ] && exit 0"
       end
 

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -420,22 +420,6 @@ module Kitchen
         INSTALL
       end
 
-      def get_rm_command
-        return 'rm -force -recurse' if powershell_shell?
-        return "#{sudo('rm')} -rf"
-      end
-
-      def get_mkdir_command
-        return 'mkdir -force -path' if powershell_shell?
-        return "#{sudo('mkdir')} -p"
-      end
-
-      def get_rm_command_paths(paths)
-        return :nil if paths.length == 0
-        return "#{get_rm_command} \"#{paths.join('", "')}\"" if powershell_shell?
-        return "#{get_rm_command} #{paths.join(' ')}"
-      end
-
       def init_command
         todelete = %w(modules manifests files hiera hiera.yaml facter spec)
                .map { |dir| File.join(config[:root_path], dir) }
@@ -478,11 +462,6 @@ module Kitchen
         instance.remote_exec remove_repo
       end
 
-      def cp
-        return 'cp -force' if powershell_shell?
-        return 'cp'
-      end
-
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def prepare_command
         commands = []
@@ -513,7 +492,7 @@ module Kitchen
 
         if puppet_config
           commands << [
-            sudo(cp),
+            sudo(get_cp_command),
             File.join(config[:root_path], 'puppet.conf'),
             puppet_dir
           ].join(' ')
@@ -521,17 +500,17 @@ module Kitchen
 
         if hiera_config
           commands << [
-            sudo(cp), File.join(config[:root_path], 'hiera.yaml'), '/etc/'
+            sudo(get_cp_command), File.join(config[:root_path], 'hiera.yaml'), '/etc/'
           ].join(' ')
 
           commands << [
-            sudo(cp), File.join(config[:root_path], 'hiera.yaml'), hiera_config_dir
+            sudo(get_cp_command), File.join(config[:root_path], 'hiera.yaml'), hiera_config_dir
           ].join(' ')
         end
 
         if fileserver_config
           commands << [
-            sudo(cp),
+            sudo(get_cp_command),
             File.join(config[:root_path], 'fileserver.conf'),
             puppet_dir
           ].join(' ')
@@ -539,7 +518,7 @@ module Kitchen
 
         if hiera_data && hiera_data_remote_path == '/var/lib/hiera'
           commands << [
-            sudo("#{cp} -r"), File.join(config[:root_path], 'hiera'), '/var/lib/'
+            sudo("#{get_cp_command} -r"), File.join(config[:root_path], 'hiera'), '/var/lib/'
           ].join(' ')
         end
 
@@ -548,7 +527,7 @@ module Kitchen
             sudo('mkdir -p'), hiera_data_remote_path
           ].join(' ')
           commands << [
-            sudo("#{cp} -r"), File.join(config[:root_path], 'hiera/*'), hiera_data_remote_path
+            sudo("#{get_cp_command} -r"), File.join(config[:root_path], 'hiera/*'), hiera_data_remote_path
           ].join(' ')
         end
 
@@ -557,7 +536,7 @@ module Kitchen
             sudo('mkdir -p'), hiera_eyaml_key_remote_path
           ].join(' ')
           commands << [
-            sudo("#{cp} -r"), File.join(config[:root_path], 'hiera_keys/*'), hiera_eyaml_key_remote_path
+            sudo("#{get_cp_command} -r"), File.join(config[:root_path], 'hiera_keys/*'), hiera_eyaml_key_remote_path
           ].join(' ')
         end
 
@@ -572,7 +551,7 @@ module Kitchen
             sudo('mkdir -p'), spec_files_remote_path
           ].join(' ')
           commands << [
-            sudo("#{cp} -r"), File.join(config[:root_path], 'spec/*'), spec_files_remote_path
+            sudo("#{get_cp_command} -r"), File.join(config[:root_path], 'spec/*'), spec_files_remote_path
           ].join(' ')
         end
 
@@ -1088,6 +1067,28 @@ module Kitchen
           ENV['SSL_CERT_FILE'] = '' if librarian_puppet_ssl_file
         end
       end
+
+      def get_cp_command
+        return 'cp -force' if powershell_shell?
+        return 'cp'
+      end
+
+      def get_rm_command
+        return 'rm -force -recurse' if powershell_shell?
+        return "#{sudo('rm')} -rf"
+      end
+
+      def get_mkdir_command
+        return 'mkdir -force -path' if powershell_shell?
+        return "#{sudo('mkdir')} -p"
+      end
+
+      def get_rm_command_paths(paths)
+        return :nil if paths.length == 0
+        return "#{get_rm_command} \"#{paths.join('", "')}\"" if powershell_shell?
+        return "#{get_rm_command} #{paths.join(' ')}"
+      end
+
     end
   end
 end

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -753,6 +753,7 @@ module Kitchen
       def puppet_manifestdir
         return nil if config[:require_puppet_collections]
         return nil if config[:puppet_environment]
+        return nil if powershell_shell?
         bash_vars = "export MANIFESTDIR='#{File.join(config[:root_path], 'manifests')}';"
         debug(bash_vars)
         bash_vars

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -835,6 +835,7 @@ module Kitchen
       end
 
       def puppet_whitelist_exit_code
+        return "; exit $LASTEXITCODE" if config[:puppet_whitelist_exit_code].nil? && powershell_shell?
         return nil if config[:puppet_whitelist_exit_code].nil?
         return "; exit ($LASTEXITCODE -ne #{config[:puppet_whitelist_exit_code]})" if powershell_shell?
         "; [ $? -eq #{config[:puppet_whitelist_exit_code]} ] && exit 0"

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -236,7 +236,6 @@ module Kitchen
                 [Environment]::SetEnvironmentVariable('Path', $env:Path, 'Machine')
               }
 
-              puppet config set stringify_facts false
               #{install_busser}
             INSTALL
           else

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -555,7 +555,7 @@ module Kitchen
           ].join(' ')
         end
 
-        command = commands.join(' && ')
+        command = powershell_shell? ? commands.join('; ') : commands.join(' && ')
         debug(command)
         command
       end

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -468,6 +468,11 @@ module Kitchen
         instance.remote_exec remove_repo
       end
 
+      def cp
+        return 'cp -force' if powershell_shell?
+        return 'cp'
+      end
+
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def prepare_command
         commands = []
@@ -498,7 +503,7 @@ module Kitchen
 
         if puppet_config
           commands << [
-            sudo('cp'),
+            sudo(cp),
             File.join(config[:root_path], 'puppet.conf'),
             puppet_dir
           ].join(' ')
@@ -506,17 +511,17 @@ module Kitchen
 
         if hiera_config
           commands << [
-            sudo('cp'), File.join(config[:root_path], 'hiera.yaml'), '/etc/'
+            sudo(cp), File.join(config[:root_path], 'hiera.yaml'), '/etc/'
           ].join(' ')
 
           commands << [
-            sudo('cp'), File.join(config[:root_path], 'hiera.yaml'), hiera_config_dir
+            sudo(cp), File.join(config[:root_path], 'hiera.yaml'), hiera_config_dir
           ].join(' ')
         end
 
         if fileserver_config
           commands << [
-            sudo('cp'),
+            sudo(cp),
             File.join(config[:root_path], 'fileserver.conf'),
             puppet_dir
           ].join(' ')
@@ -524,7 +529,7 @@ module Kitchen
 
         if hiera_data && hiera_data_remote_path == '/var/lib/hiera'
           commands << [
-            sudo('cp -r'), File.join(config[:root_path], 'hiera'), '/var/lib/'
+            sudo("#{cp} -r"), File.join(config[:root_path], 'hiera'), '/var/lib/'
           ].join(' ')
         end
 
@@ -533,7 +538,7 @@ module Kitchen
             sudo('mkdir -p'), hiera_data_remote_path
           ].join(' ')
           commands << [
-            sudo('cp -r'), File.join(config[:root_path], 'hiera/*'), hiera_data_remote_path
+            sudo("#{cp} -r"), File.join(config[:root_path], 'hiera/*'), hiera_data_remote_path
           ].join(' ')
         end
 
@@ -542,7 +547,7 @@ module Kitchen
             sudo('mkdir -p'), hiera_eyaml_key_remote_path
           ].join(' ')
           commands << [
-            sudo('cp -r'), File.join(config[:root_path], 'hiera_keys/*'), hiera_eyaml_key_remote_path
+            sudo("#{cp} -r"), File.join(config[:root_path], 'hiera_keys/*'), hiera_eyaml_key_remote_path
           ].join(' ')
         end
 
@@ -557,7 +562,7 @@ module Kitchen
             sudo('mkdir -p'), spec_files_remote_path
           ].join(' ')
           commands << [
-            sudo('cp -r'), File.join(config[:root_path], 'spec/*'), spec_files_remote_path
+            sudo("#{cp} -r"), File.join(config[:root_path], 'spec/*'), spec_files_remote_path
           ].join(' ')
         end
 

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -524,7 +524,7 @@ module Kitchen
 
         if hiera_data && hiera_data_remote_path != '/var/lib/hiera'
           commands << [
-            sudo('mkdir -p'), hiera_data_remote_path
+            sudo(get_mkdir_command), hiera_data_remote_path
           ].join(' ')
           commands << [
             sudo("#{get_cp_command} -r"), File.join(config[:root_path], 'hiera/*'), hiera_data_remote_path
@@ -533,7 +533,7 @@ module Kitchen
 
         if hiera_eyaml
           commands << [
-            sudo('mkdir -p'), hiera_eyaml_key_remote_path
+            sudo(get_mkdir_command), hiera_eyaml_key_remote_path
           ].join(' ')
           commands << [
             sudo("#{get_cp_command} -r"), File.join(config[:root_path], 'hiera_keys/*'), hiera_eyaml_key_remote_path
@@ -548,7 +548,7 @@ module Kitchen
 
         if spec_files_path && spec_files_remote_path
           commands << [
-            sudo('mkdir -p'), spec_files_remote_path
+            sudo(get_mkdir_command), spec_files_remote_path
           ].join(' ')
           commands << [
             sudo("#{get_cp_command} -r"), File.join(config[:root_path], 'spec/*'), spec_files_remote_path

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -499,9 +499,11 @@ module Kitchen
         end
 
         if hiera_config
-          commands << [
-            sudo(get_cp_command), File.join(config[:root_path], 'hiera.yaml'), '/etc/'
-          ].join(' ')
+          if !powershell_shell?
+            commands << [
+              sudo(get_cp_command), File.join(config[:root_path], 'hiera.yaml'), '/etc/'
+            ].join(' ')
+          end
 
           commands << [
             sudo(get_cp_command), File.join(config[:root_path], 'hiera.yaml'), hiera_config_dir

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -755,7 +755,7 @@ module Kitchen
       end
 
       def puppet_windows_version
-        config[:puppet_version] ? "#{config[:puppet_version]}" : nil
+        config[:puppet_version] ? "#{config[:puppet_version]}" : '3.8.6'
       end
 
       def puppet_environment_flag

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -835,7 +835,9 @@ module Kitchen
       end
 
       def puppet_whitelist_exit_code
-        config[:puppet_whitelist_exit_code] ? "; [ $? -eq #{config[:puppet_whitelist_exit_code]} ] && exit 0" : nil
+        return nil if config[:puppet_whitelist_exit_code].nil?
+        return "; exit ($LASTEXITCODE -ne #{config[:puppet_whitelist_exit_code]})" if powershell_shell?
+        "; [ $? -eq #{config[:puppet_whitelist_exit_code]} ] && exit 0"
       end
 
       def puppet_apt_repo

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -711,19 +711,15 @@ module Kitchen
       end
 
       def puppet_dir
-        if config[:require_puppet_collections]
-          '/etc/puppetlabs/puppet'
-        else
-          '/etc/puppet'
-        end
+        return '/etc/puppetlabs/puppet' if config[:require_puppet_collections]
+        return '/etc/puppet' if !powershell_shell?
+        return 'C:/ProgramData/PuppetLabs/puppet/etc'
       end
 
       def hiera_config_dir
-        if config[:require_puppet_collections]
-          '/etc/puppetlabs/code'
-        else
-          '/etc/puppet'
-        end
+        return '/etc/puppetlabs/code' if config[:require_puppet_collections]
+        return '/etc/puppet' if !powershell_shell?
+        return 'C:/ProgramData/PuppetLabs/puppet/etc'
       end
 
       def puppet_debian_version

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -572,5 +572,27 @@ CUSTOM_COMMAND
       config[:puppet_whitelist_exit_code] = '2'
       expect(provisioner.run_command).to match(/; \[ \$\? -eq 2 \] && exit 0$/)
     end
+
+    it 'whitelists multiple exit codes' do
+      config[:puppet_whitelist_exit_code] = ['2', '4']
+      expect(provisioner.run_command).to match(/; \[ \$\? -eq \["2", "4"\] \] && exit 0$/)
+    end
+  end
+
+  context 'run command on windows' do
+    before do
+      allow_any_instance_of(Kitchen::Configurable).to receive(:powershell_shell?).and_return(true)
+      allow_any_instance_of(Kitchen::Configurable).to receive(:windows_os?).and_return(true)
+    end
+
+    it 'whitelists exit code' do
+      config[:puppet_whitelist_exit_code] = '2'
+      expect(provisioner.run_command).to match(/; if\(@\(2\) -contains \$LASTEXITCODE\) {exit 0} else {exit \$LASTEXITCODE}$/)
+    end
+
+    it 'whitelists multiple exit codes' do
+      config[:puppet_whitelist_exit_code] = ['2', '4']
+      expect(provisioner.run_command).to match(/; if\(@\(2, 4\) -contains \$LASTEXITCODE\) {exit 0} else {exit \$LASTEXITCODE}$/)
+    end
   end
 end

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -585,7 +585,12 @@ CUSTOM_COMMAND
       allow_any_instance_of(Kitchen::Configurable).to receive(:windows_os?).and_return(true)
     end
 
-    it 'whitelists exit code' do
+    it 'does not whitelist exit codes by default' do
+      config[:puppet_whitelist_exit_code] = nil
+      expect(provisioner.run_command).to match(/; exit \$LASTEXITCODE$/)
+    end
+
+    it 'whitelists a single exit code' do
       config[:puppet_whitelist_exit_code] = '2'
       expect(provisioner.run_command).to match(/; if\(@\(2\) -contains \$LASTEXITCODE\) {exit 0} else {exit \$LASTEXITCODE}$/)
     end

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -633,6 +633,7 @@ CUSTOM_COMMAND
     context 'When using powershell' do
       before do
         allow_any_instance_of(Kitchen::Configurable).to receive(:powershell_shell?).and_return(true)
+        allow_any_instance_of(Kitchen::Configurable).to receive(:windows_os?).and_return(true)
       end
 
       describe 'puppet_dir' do
@@ -668,6 +669,12 @@ CUSTOM_COMMAND
       describe 'get_rm_command_paths(path1, path2)' do
         it 'is rm -force -recurse "path1", "path2"' do
           expect(provisioner.send(:get_rm_command_paths, ['path1', 'path2'])).to eq('rm -force -recurse "path1", "path2"')
+        end
+      end
+
+      describe 'puppet_cmd' do
+        it 'is & "C:\Program Files\Puppet Labs\Puppet\bin\puppet"' do
+          expect(provisioner.send(:puppet_cmd)).to eq('& "C:\Program Files\Puppet Labs\Puppet\bin\puppet"')
         end
       end
     end
@@ -706,6 +713,12 @@ CUSTOM_COMMAND
       describe 'get_rm_command_paths(path1, path2)' do
         it 'is sudo -E rm -rf path1 path2' do
           expect(provisioner.send(:get_rm_command_paths, ['path1', 'path2'])).to eq('sudo -E rm -rf path1 path2')
+        end
+      end
+
+      describe 'puppet_cmd' do
+        it 'is puppet' do
+          expect(provisioner.send(:puppet_cmd)).to eq('sudo -E puppet')
         end
       end
     end

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -700,19 +700,19 @@ CUSTOM_COMMAND
 
       describe 'get_rm_command' do
         it 'is sudo -E rm -rf' do
-          expect(provisioner.send(:get_rm_command)).to eq('sudo -E rm -rf')
+          expect(provisioner.send(:get_rm_command)).to eq('rm -rf')
         end
       end
 
       describe 'get_mkdir_command' do
         it 'is sudo -E mkdir -p' do
-          expect(provisioner.send(:get_mkdir_command)).to eq('sudo -E mkdir -p')
+          expect(provisioner.send(:get_mkdir_command)).to eq('mkdir -p')
         end
       end
 
       describe 'get_rm_command_paths(path1, path2)' do
         it 'is sudo -E rm -rf path1 path2' do
-          expect(provisioner.send(:get_rm_command_paths, ['path1', 'path2'])).to eq('sudo -E rm -rf path1 path2')
+          expect(provisioner.send(:get_rm_command_paths, ['path1', 'path2'])).to eq('rm -rf path1 path2')
         end
       end
 

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -616,23 +616,85 @@ CUSTOM_COMMAND
     end
   end
 
-  context 'puppet_dir' do
-    before do
-      allow_any_instance_of(Kitchen::Configurable).to receive(:powershell_shell?).and_return(true)
+  describe 'protected methods' do
+    context 'When using powershell' do
+      before do
+        allow_any_instance_of(Kitchen::Configurable).to receive(:powershell_shell?).and_return(true)
+      end
+
+      describe 'puppet_dir' do
+        it 'is C:/ProgramData/PuppetLabs/puppet/etc' do
+          expect(provisioner.send(:puppet_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
+        end
+      end
+
+      describe 'hiera_config_dir' do
+        it 'is C:/ProgramData/PuppetLabs/puppet/etc' do
+          expect(provisioner.send(:hiera_config_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
+        end
+      end
+
+      describe 'get_cp_command' do
+        it 'is cp -force' do
+          expect(provisioner.send(:get_cp_command)).to eq('cp -force')
+        end
+      end
+
+      describe 'get_rm_command' do
+        it 'is rm -force -recurse' do
+          expect(provisioner.send(:get_rm_command)).to eq('rm -force -recurse')
+        end
+      end
+
+      describe 'get_mkdir_command' do
+        it 'is mkdir -force -path' do
+          expect(provisioner.send(:get_mkdir_command)).to eq('mkdir -force -path')
+        end
+      end
+
+      describe 'get_rm_command_paths(path1, path2)' do
+        it 'is rm -force -recurse "path1", "path2"' do
+          expect(provisioner.send(:get_rm_command_paths, ['path1', 'path2'])).to eq('rm -force -recurse "path1", "path2"')
+        end
+      end
     end
 
-    it 'is C:/ProgramData/PuppetLabs/puppet/etc' do
-      expect(provisioner.send(:puppet_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
-    end
-  end
+    context 'When NOT using powershell' do
+      describe 'puppet_dir' do
+        it 'is /etc/puppet' do
+          expect(provisioner.send(:puppet_dir)).to eq('/etc/puppet')
+        end
+      end
 
-  context 'hiera_config_dir' do
-    before do
-      allow_any_instance_of(Kitchen::Configurable).to receive(:powershell_shell?).and_return(true)
-    end
+      describe 'hiera_config_dir' do
+        it 'is /etc/puppet' do
+          expect(provisioner.send(:hiera_config_dir)).to eq('/etc/puppet')
+        end
+      end
 
-    it 'is C:/ProgramData/PuppetLabs/puppet/etc' do
-      expect(provisioner.send(:hiera_config_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
+      describe 'get_cp_command' do
+        it 'is cp' do
+          expect(provisioner.send(:get_cp_command)).to eq('cp')
+        end
+      end
+
+      describe 'get_rm_command' do
+        it 'is sudo -E rm -rf' do
+          expect(provisioner.send(:get_rm_command)).to eq('sudo -E rm -rf')
+        end
+      end
+
+      describe 'get_mkdir_command' do
+        it 'is sudo -E mkdir -p' do
+          expect(provisioner.send(:get_mkdir_command)).to eq('sudo -E mkdir -p')
+        end
+      end
+
+      describe 'get_rm_command_paths(path1, path2)' do
+        it 'is sudo -E rm -rf path1 path2' do
+          expect(provisioner.send(:get_rm_command_paths, ['path1', 'path2'])).to eq('sudo -E rm -rf path1 path2')
+        end
+      end
     end
   end
 end

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -563,6 +563,11 @@ CUSTOM_COMMAND
       expect(provisioner.run_command).to include("export FACTERLIB='/tmp/kitchen/facter';")
     end
 
+    it 'exports custom_facts' do
+      config[:custom_facts] = {fact1: 'value1', fact2: 'value2'}
+      expect(provisioner.run_command).to include("export FACTER_fact1=value1 FACTER_fact2=value2;")
+    end
+
     it 'custom options should appear in run command' do
       config[:custom_options] = '--no-stringify_facts'
       expect(provisioner.run_command).to include('--no-stringify_facts')
@@ -583,6 +588,16 @@ CUSTOM_COMMAND
     before do
       allow_any_instance_of(Kitchen::Configurable).to receive(:powershell_shell?).and_return(true)
       allow_any_instance_of(Kitchen::Configurable).to receive(:windows_os?).and_return(true)
+    end
+
+    it 'exports custom_facts' do
+      config[:custom_facts] = {fact1: 'value1', fact2: 'value2'}
+      expect(provisioner.run_command).to include("\$env:FACTER_fact1='value1'; \$env:FACTER_fact2='value2';")
+    end
+
+    it 'custom options should appear in run command' do
+      config[:custom_options] = '--no-stringify_facts'
+      expect(provisioner.run_command).to include('--no-stringify_facts')
     end
 
     it 'does not whitelist exit codes by default' do

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -600,4 +600,24 @@ CUSTOM_COMMAND
       expect(provisioner.run_command).to match(/; if\(@\(2, 4\) -contains \$LASTEXITCODE\) {exit 0} else {exit \$LASTEXITCODE}$/)
     end
   end
+
+  context 'puppet_dir' do
+    before do
+      allow_any_instance_of(Kitchen::Configurable).to receive(:powershell_shell?).and_return(true)
+    end
+
+    it 'is C:/ProgramData/PuppetLabs/puppet/etc' do
+      expect(provisioner.send(:puppet_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
+    end
+  end
+
+  context 'hiera_config_dir' do
+    before do
+      allow_any_instance_of(Kitchen::Configurable).to receive(:powershell_shell?).and_return(true)
+    end
+
+    it 'is C:/ProgramData/PuppetLabs/puppet/etc' do
+      expect(provisioner.send(:hiera_config_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
+    end
+  end
 end


### PR DESCRIPTION
This is an attempt at adding some windows/winrm support (I don't think everything works) for the puppet apply provisioner. Hopefully this can help moving forward on #79 :smile: 

Here is a module showing how we are currently using it: https://github.com/red-gate/puppet-virtualbox_windows 
We currently use these options:
* `require_chef_for_busser: false` (we call rspec over winrm to run the tests) 
* `resolve_with_librarian_puppet: false` (I couldn't get it to work at the time)

Does this look like the right approach?

