### PR TITLE
Introduce custom_post_install command

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -64,6 +64,7 @@ module Kitchen
       default_config :puppet_logdest, nil
       default_config :custom_install_command, nil
       default_config :custom_pre_install_command, nil
+      default_config :custom_post_install_command, nil
       default_config :puppet_whitelist_exit_code, nil
       default_config :require_puppet_omnibus, false
       default_config :puppet_omnibus_url, 'https://raw.githubusercontent.com/petems/puppet-install-shell/master/install_puppet.sh'
@@ -603,6 +604,12 @@ module Kitchen
             puppet_logdest_flag,
             puppet_whitelist_exit_code
           ].join(' ')
+          if config[:custom_post_install_command]
+            result = <<-RUN
+              #{config[:custom_post_install_command]}
+              #{result}
+            RUN
+          end
           info("Going to invoke puppet apply with: #{result}")
           result
         end

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -590,5 +590,19 @@ CUSTOM_COMMAND
       config[:puppet_no_sudo] = false
       expect(provisioner.run_command).to include('sudo -E')
     end
+
+    it 'runs custom shell command at post install stage' do
+      config[:custom_post_install_command] = 'echo "CUSTOM_SHELL"'
+      expect(provisioner.run_command).to include('echo "CUSTOM_SHELL"')
+    end
+
+    it 'runs multiline custom shell command at post install stage' do
+      config[:custom_post_install_command] = <<CUSTOM_COMMAND
+echo "string1"
+echo "string2"
+CUSTOM_COMMAND
+
+      expect(provisioner.run_command).to include(%(echo "string1"\necho "string2"))
+    end
   end
 end


### PR DESCRIPTION
* Executes command right before puppet converge
* Useful to setup custom things(e.g. testing mock services ) right
  before puppet execution
* Technically extends provisioner's run_command