### PR TITLE
Fix exporting https_proxy env var during Omnibus installs

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -988,7 +988,7 @@ module Kitchen
       end
 
       def export_https_proxy_parm
-        http_proxy ? "export https_proxy=#{http_proxy}" : nil
+        https_proxy ? "export https_proxy=#{https_proxy}" : nil
       end
 
       def http_proxy


### PR DESCRIPTION
Looks like a typo, it should export https_proxy instead of http_proxy.