### PR TITLE
Use expand_path to set absolute path for puppetfile_path

### DIFF
--- a/lib/kitchen/provisioner/puppet/librarian.rb
+++ b/lib/kitchen/provisioner/puppet/librarian.rb
@@ -44,7 +44,7 @@ module Kitchen
           debug("Using Puppetfile from #{puppetfile}")
 
           env = ::Librarian::Puppet::Environment.new(
-            project_path: File.dirname(puppetfile)
+            project_path: File.expand_path(File.dirname(puppetfile)),
           )
 
           env.config_db.local['path'] = path

--- a/lib/kitchen/provisioner/puppet/librarian.rb
+++ b/lib/kitchen/provisioner/puppet/librarian.rb
@@ -41,14 +41,13 @@ module Kitchen
         def resolve
           version = ::Librarian::Puppet::VERSION
           info("Resolving module dependencies with Librarian-Puppet #{version}...")
-          info("Using Puppetfile from #{puppetfile}")
+          debug("Using Puppetfile from #{puppetfile}")
 
           env = ::Librarian::Puppet::Environment.new(
             project_path: File.dirname(puppetfile)
           )
 
           env.config_db.local['path'] = path
-          info("Env is: #{env.inspect}")
           ::Librarian::Action::Resolve.new(env).run
           ::Librarian::Action::Install.new(env).run
         end

--- a/lib/kitchen/provisioner/puppet/librarian.rb
+++ b/lib/kitchen/provisioner/puppet/librarian.rb
@@ -41,13 +41,14 @@ module Kitchen
         def resolve
           version = ::Librarian::Puppet::VERSION
           info("Resolving module dependencies with Librarian-Puppet #{version}...")
-          debug("Using Puppetfile from #{puppetfile}")
+          info("Using Puppetfile from #{puppetfile}")
 
           env = ::Librarian::Puppet::Environment.new(
             project_path: File.dirname(puppetfile)
           )
 
           env.config_db.local['path'] = path
+          info("Env is: #{env.inspect}")
           ::Librarian::Action::Resolve.new(env).run
           ::Librarian::Action::Install.new(env).run
         end


### PR DESCRIPTION
This fixes #85 

We were experiencing the same issue as the OP, and it turns out it was because the `puppetfile_path` config wasn't referencing an absolute path. Once this was changed, relocating the `Puppetfile` to `spec/fixtures` (or any other path) works as expected. 

This change will work fine with existing implementations, as `File.expand_path` will be a noop on the default `puppetfile_path`, as that is already an absolute path.