### PR TITLE
Support installing Puppet 4+ on windows

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -763,10 +763,9 @@ module Kitchen
       end
 
       def puppet_cmd
-        puppet_bin = powershell_shell? ? '& "C:\Program Files\Puppet Labs\Puppet\bin\puppet"' : 'puppet'
-        if config[:require_puppet_collections]
-          puppet_bin = "#{config[:puppet_coll_remote_path]}/bin/puppet"
-        end
+        return '& "C:\Program Files\Puppet Labs\Puppet\bin\puppet"' if powershell_shell?
+
+        puppet_bin = config[:require_puppet_collections] ? "#{config[:puppet_coll_remote_path]}/bin/puppet" : 'puppet'
 
         if config[:puppet_no_sudo]
           puppet_bin

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -775,15 +775,13 @@ module Kitchen
       end
 
       def puppet_dir
-        return '/etc/puppetlabs/puppet' if config[:require_puppet_collections]
-        return '/etc/puppet' unless powershell_shell?
-        'C:/ProgramData/PuppetLabs/puppet/etc'
+        return 'C:/ProgramData/PuppetLabs/puppet/etc' if powershell_shell?
+        config[:require_puppet_collections] ? '/etc/puppetlabs/puppet' : '/etc/puppet'
       end
 
       def hiera_config_dir
-        return '/etc/puppetlabs/code' if config[:require_puppet_collections]
-        return '/etc/puppet' unless powershell_shell?
-        'C:/ProgramData/PuppetLabs/puppet/etc'
+        return 'C:/ProgramData/PuppetLabs/puppet/etc' if powershell_shell?
+        config[:require_puppet_collections] ? '/etc/puppetlabs/code' : '/etc/puppet'
       end
 
       def puppet_debian_version

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -305,6 +305,23 @@ module Kitchen
           #{install_busser}
           #{custom_install_command}
           INSTALL
+        when /^windows.*/
+          info("Installing Puppet Collections on #{puppet_platform}")
+          <<-INSTALL
+            if(Get-Command puppet -ErrorAction 0) { return; }
+            if( [Environment]::Is64BitOperatingSystem ) {
+                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-#{puppet_windows_version}-x64.msi"
+            } else {
+                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-#{puppet_windows_version}-x86.msi"
+            }
+            $process = Start-Process -FilePath msiexec.exe -Wait -PassThru -ArgumentList '/qn', '/norestart', '/i', $MsiUrl
+            if ($process.ExitCode -ne 0) {
+                Write-Host "Installer failed."
+                Exit 1
+            }
+
+            #{install_busser}
+          INSTALL
         else
           info('Installing Puppet Collections, will try to determine platform os')
           <<-INSTALL

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -221,10 +221,11 @@ module Kitchen
             info("Installing puppet on #{puppet_platform}")
             <<-INSTALL
               if(Get-Command puppet -ErrorAction 0) { return; }
-              if( [Environment]::Is64BitOperatingSystem ) {
-                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-#{puppet_windows_version}-x64.msi"
+              $architecture = if( [Environment]::Is64BitOperatingSystem ) { '-x64' } else { '' }
+              if( '#{puppet_windows_version}' -eq 'latest' ) {
+                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet${architecture}-latest.msi"
               } else {
-                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-#{puppet_windows_version}.msi"
+                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-#{puppet_windows_version}${architecture}.msi"
               }
               $process = Start-Process -FilePath msiexec.exe -Wait -PassThru -ArgumentList '/qn', '/norestart', '/i', $MsiUrl
               if ($process.ExitCode -ne 0) {
@@ -309,10 +310,11 @@ module Kitchen
           info("Installing Puppet Collections on #{puppet_platform}")
           <<-INSTALL
             if(Get-Command puppet -ErrorAction 0) { return; }
-            if( [Environment]::Is64BitOperatingSystem ) {
-                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-#{puppet_windows_version}-x64.msi"
+            $architecture = if( [Environment]::Is64BitOperatingSystem ) { 'x64' } else { 'x86' }
+            if( '#{puppet_windows_version}' -eq 'latest' ) {
+                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-${architecture}-latest.msi"
             } else {
-                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-#{puppet_windows_version}-x86.msi"
+                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
             }
             $process = Start-Process -FilePath msiexec.exe -Wait -PassThru -ArgumentList '/qn', '/norestart', '/i', $MsiUrl
             if ($process.ExitCode -ne 0) {
@@ -805,7 +807,7 @@ module Kitchen
       end
 
       def puppet_windows_version
-        config[:puppet_version] ? config[:puppet_version].to_s : '3.8.6'
+        config[:puppet_version] ? config[:puppet_version].to_s : 'latest'
       end
 
       def puppet_environment_flag

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -710,6 +710,10 @@ CUSTOM_COMMAND
         it 'is & "C:\Program Files\Puppet Labs\Puppet\bin\puppet"' do
           expect(provisioner.send(:puppet_cmd)).to eq('& "C:\Program Files\Puppet Labs\Puppet\bin\puppet"')
         end
+        it 'is & "C:\Program Files\Puppet Labs\Puppet\bin\puppet" when using puppet collections' do
+          config[:require_puppet_collections] = true
+          expect(provisioner.send(:puppet_cmd)).to eq('& "C:\Program Files\Puppet Labs\Puppet\bin\puppet"')
+        end
       end
     end
 

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -674,10 +674,18 @@ CUSTOM_COMMAND
         it 'is C:/ProgramData/PuppetLabs/puppet/etc' do
           expect(provisioner.send(:puppet_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
         end
+        it 'is C:/ProgramData/PuppetLabs/puppet/etc when using puppet collections' do
+          config[:require_puppet_collections] = true
+          expect(provisioner.send(:puppet_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
+        end
       end
 
       describe 'hiera_config_dir' do
         it 'is C:/ProgramData/PuppetLabs/puppet/etc' do
+          expect(provisioner.send(:hiera_config_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
+        end
+        it 'is C:/ProgramData/PuppetLabs/puppet/etc when using puppet collections' do
+          config[:require_puppet_collections] = true
           expect(provisioner.send(:hiera_config_dir)).to eq('C:/ProgramData/PuppetLabs/puppet/etc')
         end
       end


### PR DESCRIPTION
This PR add supports for installing Puppet 4+ on Windows. (Using the `puppet-agent` installers available at https://downloads.puppetlabs.com/windows) 

* It is using the existing `require_puppet_collections` parameter.
  * If set to `true`, the `puppet-agent` installers are used (Puppet 4)
  * If set to `false`, the `puppet` installers are used (Puppet 3)

I also fixed the Puppet 3 install logic to allow `puppet_version` to be set to `latest`. (and made this the default)