### PR TITLE
Fix copy of hiera data files

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -564,13 +564,7 @@ module Kitchen
           ].join(' ')
         end
 
-        if hiera_data && hiera_data_remote_path == '/var/lib/hiera'
-          commands << [
-            sudo("#{cp_command} -r"), File.join(config[:root_path], 'hiera'), '/var/lib/'
-          ].join(' ')
-        end
-
-        if hiera_data && hiera_data_remote_path != '/var/lib/hiera'
+        if hiera_data
           commands << [
             sudo(mkdir_command), hiera_data_remote_path
           ].join(' ')


### PR DESCRIPTION
I believe this code is redundant...

On windows, hiera data files end up being copied  to `C:/var/lib/` instead of `C:/var/lib/hiera` when `hiera_data_remote_path` is set to `/var/lib/hiera`. (I suspect because `C:/var/lib/hiera` does not exist by default)

With this change, the `C:/var/lib/hiera` folder is created before the copy and files do end up being copied to `C:/var/lib/hiera`.

Not sure why there is special logic that skip creating `/var/lib/hiera` in the first place?