### PR TITLE
Add future parser option to puppet apply

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -141,6 +141,7 @@ module Kitchen
       default_config :puppet_verbose, false
       default_config :puppet_noop, false
       default_config :puppet_show_diff, false
+      default_config :puppet_future_parser, false
       default_config :platform, &:platform_name
       default_config :update_package_repos, true
       default_config :remove_puppet_repo, false
@@ -691,6 +692,7 @@ module Kitchen
           puppet_verbose_flag,
           puppet_debug_flag,
           puppet_logdest_flag,
+          puppet_future_parser_flag,
           puppet_show_diff_flag,
           puppet_whitelist_exit_code
         ].join(' ')
@@ -905,6 +907,10 @@ module Kitchen
 
       def puppet_show_diff_flag
         config[:puppet_show_diff] ? '--show_diff' : nil
+      end
+
+      def puppet_future_parser_flag
+        config[:puppet_future_parser] ? '--parser=future' : nil
       end
 
       def puppet_logdest_flag

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -78,6 +78,7 @@ puppet_debug| false| Enable full debugging logging on puppet run
 puppet_detailed_exitcodes | nil | Provide transaction information via exit codes. See `--detailed-exitcodes` section of `puppet help apply`
 puppet_enc | | path for external node classifier script
 puppet_environment | nil | puppet environment for running puppet apply (Must set if using Puppet v4)
+puppet_future_parser | false | Run puppet with the future parser enabled  (see https://docs.puppet.com/puppet/3.8/experiments_future.html).
 puppet_git_init | nil | initialize puppet from GIT repository, e.g. "git@github.com:example/puppet-repo.git"
 puppet_git_pr | nil | checkout specific Pull Request from repository specified in puppet_git_init, e.g. "324"
 puppet_logdest | nil | _Array_ of log destinations. Include 'console' if wanted


### PR DESCRIPTION
Hi there, this allows the option to run puppet with `--parser=future` enabled. This is useful if you're testing with puppet 3 modules which use the future parser features ( see https://docs.puppet.com/puppet/3.8/experiments_future.html )