### PR TITLE
Fix default values for hiera_data_remote_path based on puppet_version

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -788,7 +788,12 @@ module Kitchen
 
       def hiera_data_remote_path
         return config[:hiera_data_remote_path] if config[:hiera_data_remote_path]
-        powershell? ? 'C:/ProgramData/PuppetLabs/hiera/var' : '/var/lib/hiera'
+
+        if config[:require_puppet_collections]
+          powershell? ? 'C:/ProgramData/PuppetLabs/code/environments/production/hieradata' : '/etc/puppetlabs/code/environments/production/hieradata'
+        else
+          powershell? ? 'C:/ProgramData/PuppetLabs/hiera/var' : '/var/lib/hiera'
+        end
       end
 
       def hiera_writer

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -685,8 +685,14 @@ CUSTOM_COMMAND
       end
 
       describe 'hiera_data_remote_path' do
-        it 'is C:/ProgramData/PuppetLabs/hiera/var' do
+        it 'is C:/ProgramData/PuppetLabs/hiera/var when using puppet v3' do
+          config[:require_puppet_collections] = false
           expect(provisioner.send(:hiera_data_remote_path)).to eq('C:/ProgramData/PuppetLabs/hiera/var')
+        end
+
+        it 'is C:/ProgramData/PuppetLabs/code/environments/production/hieradata when using puppet v4' do
+          config[:require_puppet_collections] = true
+          expect(provisioner.send(:hiera_data_remote_path)).to eq('C:/ProgramData/PuppetLabs/code/environments/production/hieradata')
         end
       end
 
@@ -747,8 +753,14 @@ CUSTOM_COMMAND
 
     context 'When NOT using powershell' do
       describe 'hiera_data_remote_path' do
-        it 'is /var/lib/hiera' do
+        it 'is /var/lib/hiera when using puppet v3' do
+          config[:require_puppet_collections] = false
           expect(provisioner.send(:hiera_data_remote_path)).to eq('/var/lib/hiera')
+        end
+
+        it 'is /etc/puppetlabs/code/environments/production/hieradata when using puppet v4' do
+          config[:require_puppet_collections] = true
+          expect(provisioner.send(:hiera_data_remote_path)).to eq('/etc/puppetlabs/code/environments/production/hieradata')
         end
       end
 


### PR DESCRIPTION
Following up on #166 this change sets the default value of hiera's `datadir` based on the version of puppet installed.

* For puppet v3 (no change):
  * windows: `C:/ProgramData/PuppetLabs/hiera/var`
  * linux: `/var/lib/hiera`
* For puppet v4 and later:
  * windows: `C:/ProgramData/PuppetLabs/code/environments/production/hieradata`
  * linux: `/etc/puppetlabs/code/environments/production/hieradata`