### PR TITLE
Puppet 3 is EOL

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -46,7 +46,7 @@ module Kitchen
     class PuppetApply < Base
       attr_accessor :tmp_dir
 
-      default_config :require_puppet_collections, false
+      default_config :require_puppet_collections, true
       default_config :puppet_yum_collections_repo, 'http://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm'
       default_config :puppet_apt_collections_repo, 'http://apt.puppetlabs.com/puppetlabs-release-pc1-wheezy.deb'
       default_config :puppet_coll_remote_path, '/opt/puppetlabs'

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -9,7 +9,7 @@ It installs it in the following order:
 
    Installs using the omnibus_puppet script and passes the puppet_version if specied as -v option.
 
-* If require_puppet_collections is set to true
+* If require_puppet_collections is set to true (the default)
 
    Installs from the puppet collection.
    This is required if you wish to install puppet version 4.
@@ -105,7 +105,7 @@ _for RH/Centos7 change to_ | "https://yum.puppetlabs.com/puppetlabs-release-pc1-
 puppetfile_path | | Path to Puppetfile
 remove_puppet_repo | false | remove copy of puppet repository and puppet configuration on server after running puppet
 require_chef_for_busser | true | Install chef as currently needed by busser to run tests
-require_puppet_collections | false | Set if using puppet collections install (Puppet v4)
+require_puppet_collections | true | Set if using puppet collections install (Puppet v4)
 require_puppet_omnibus | false | Set if using omnibus puppet install
 require_puppet_repo | true | Set if using a puppet install from yum or apt repo
 resolve_with_librarian_puppet | true | Use librarian_puppet to resolve modules if a Puppetfile is found

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -67,7 +67,7 @@ describe Kitchen::Provisioner::PuppetApply do
       end
 
       it 'should not include puppet collections' do
-        expect(provisioner[:require_puppet_collections]).to eq(false)
+        expect(provisioner[:require_puppet_collections]).to eq(true)
       end
 
       it 'should set yum collections repo' do
@@ -265,8 +265,8 @@ describe Kitchen::Provisioner::PuppetApply do
 
     context 'non-default sets' do
       it 'requires puppet collections' do
-        config[:require_puppet_collections] = true
-        expect(provisioner[:require_puppet_collections]).to eq(true)
+        config[:require_puppet_collections] = false
+        expect(provisioner[:require_puppet_collections]).to eq(false)
       end
 
       it 'sets yum collections repo' do
@@ -754,14 +754,14 @@ describe Kitchen::Provisioner::PuppetApply do
       end
 
       describe 'puppet_dir' do
-        it 'is /etc/puppet' do
-          expect(provisioner.send(:puppet_dir)).to eq('/etc/puppet')
+        it 'is /etc/puppetlabs/puppet' do
+          expect(provisioner.send(:puppet_dir)).to eq('/etc/puppetlabs/puppet')
         end
       end
 
       describe 'hiera_config_dir' do
-        it 'is /etc/puppet' do
-          expect(provisioner.send(:hiera_config_dir)).to eq('/etc/puppet')
+        it 'is /etc/puppetlabs/code' do
+          expect(provisioner.send(:hiera_config_dir)).to eq('/etc/puppetlabs/code')
         end
       end
 
@@ -790,8 +790,8 @@ describe Kitchen::Provisioner::PuppetApply do
       end
 
       describe 'puppet_cmd' do
-        it 'is puppet' do
-          expect(provisioner.send(:puppet_cmd)).to eq('sudo -E puppet')
+        it 'is /opt/puppetlabs/bin/puppet' do
+          expect(provisioner.send(:puppet_cmd)).to eq('sudo -E /opt/puppetlabs/bin/puppet')
         end
       end
     end


### PR DESCRIPTION
Puppet 3 has been end of life for a while now [1] so lets make the collections install method (and puppet 4/5) the default.

[1] https://rnelson0.com/2016/10/25/puppet-3-end-of-life-12312016/