### PR TITLE
Add array support to custom facts

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -1236,7 +1236,7 @@ module Kitchen
           facter_facts.each do |k, v|
             out.write "\nFacter.add(:#{k}) do\n"
             out.write "  setcode do\n"
-            if v.is_a?(Hash)
+            if [Array, Hash].include? v.class
               out.write "    #{v}\n"
             else
               out.write "    \"#{v}\"\n"


### PR DESCRIPTION
Previously only worked with Hash, now supports arrays. 
ex:

```
list_of_ips:
  - 10.0.0.1
  - 192.168.10.10
```

Previous Output:
```
Facter.add(:ossec_manager_ips) do
  setcode do
    "["10.0.0.1", "192.168.10.10"]"
  end
end
```

New Output:
```
Facter.add(:ossec_manager_ips) do
  setcode do
    ["10.0.0.1", "192.168.10.10"]
  end
end
```

Current issues:
 - Cannot create an empty list. (Is there a better way to be adding facts other than passing them into kitchen.yml?)