### PR TITLE
Updated URL for chef

### DIFF
--- a/lib/kitchen/provisioner/puppet_agent.rb
+++ b/lib/kitchen/provisioner/puppet_agent.rb
@@ -52,7 +52,7 @@ module Kitchen
 
       default_config :puppet_apt_repo, 'http://apt.puppetlabs.com/puppetlabs-release-precise.deb'
       default_config :puppet_yum_repo, 'https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm'
-      default_config :chef_bootstrap_url, 'https://www.getchef.com/chef/install.sh'
+      default_config :chef_bootstrap_url, 'https://www.chef.io/chef/install.sh'
 
       default_config :puppet_agent_command, nil
 

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -71,7 +71,7 @@ module Kitchen
       end
       default_config :puppet_apt_repo, 'http://apt.puppetlabs.com/puppetlabs-release-precise.deb'
       default_config :puppet_yum_repo, 'https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm'
-      default_config :chef_bootstrap_url, 'https://www.getchef.com/chef/install.sh'
+      default_config :chef_bootstrap_url, 'https://www.chef.io/chef/install.sh'
       default_config :puppet_logdest, nil
       default_config :custom_install_command, nil
       default_config :custom_pre_install_command, nil

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -27,7 +27,7 @@ It installs it in the following order:
 
 key | default value | Notes
 ----|---------------|--------
-chef_bootstrap_url | https://www.getchef.com/ chef/install.sh | the chef (needed for busser to run tests) NOTE: kitchen 1.4 only requires ruby to run busser so this is not required.
+chef_bootstrap_url | https://www.chef.io/ chef/install.sh | the chef (needed for busser to run tests) NOTE: kitchen 1.4 only requires ruby to run busser so this is not required.
 custom_facts| Hash.new | Hash to set the puppet facts before running puppet apply
 custom_options | | custom options to add to puppet apply command.
 custom_pre_install_command | nil | Custom shell command to be used at beginning of install stage. Can be multiline.
@@ -232,7 +232,7 @@ puppet_noop| false| puppet runs in a no-op or dry-run mode
 update_package_repos| true| update OS repository metadata
 custom_facts| Hash.new | Hash to set the puppet facts before running puppet apply
 facterlib | nil | Path for dynamic fact generation, e.g. /etc/puppet/facter . See https://docs.puppetlabs.com/facter/2.2/custom_facts.html
-chef_bootstrap_url |"https://www.getchef.com/chef/install.sh"| the chef (needed for busser to run tests)
+chef_bootstrap_url |"https://www.chef.io/chef/install.sh"| the chef (needed for busser to run tests)
 puppet_agent_command | nil | Overwrite the puppet agent command. Needs "sudo -E puppet agent" as a prefix.
 require_chef_for_busser | true | Install chef as currently needed by busser to run tests. NOTE: kitchen 1.4 only requires ruby to run busser so this is not required.
 puppet_config_path | | path of custom puppet.conf file

--- a/spec/kitchen/provisioner/puppet_agent_spec.rb
+++ b/spec/kitchen/provisioner/puppet_agent_spec.rb
@@ -87,7 +87,7 @@ describe Kitchen::Provisioner::PuppetAgent do
       end
 
       it 'Should set correct chef bootstrap url' do
-        expect(provisioner[:chef_bootstrap_url]).to eq('https://www.getchef.com/chef/install.sh')
+        expect(provisioner[:chef_bootstrap_url]).to eq('https://www.chef.io/chef/install.sh')
       end
 
       it 'Should set nil puppet log destination' do

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -111,7 +111,7 @@ describe Kitchen::Provisioner::PuppetApply do
       end
 
       it 'Should set correct chef bootstrap url' do
-        expect(provisioner[:chef_bootstrap_url]).to eq('https://www.getchef.com/chef/install.sh')
+        expect(provisioner[:chef_bootstrap_url]).to eq('https://www.chef.io/chef/install.sh')
       end
 
       it 'Should set nil puppet log destination' do


### PR DESCRIPTION
getchef.com is 301'd to chef.io which is the future looking domain.

Signed-off-by: JJ Asghar <jj@chef.io>