### PR TITLE
Add Kitchen logger to Librarian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
   - 2.3.1
   - 2.3.4
-  - 2.4.1
+  - 2.4.4
+  - 2.5.1
 
 sudo: required
 services:

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'kitchen-docker', '~> 2.6.0'
+gem 'librarian-puppet', '~> 3.0.0'
 gem 'rake', '~> 10.4.2'
 gem 'rspec', '~> 3.3.0'
 gem 'rubocop', '~> 0.49.0'

--- a/lib/kitchen-puppet/version.rb
+++ b/lib/kitchen-puppet/version.rb
@@ -2,6 +2,6 @@
 
 module Kitchen
   module Puppet
-    VERSION = '3.3.2'.freeze
+    VERSION = '3.4.0'.freeze
   end
 end

--- a/lib/kitchen-puppet/version.rb
+++ b/lib/kitchen-puppet/version.rb
@@ -2,6 +2,6 @@
 
 module Kitchen
   module Puppet
-    VERSION = '3.3.1'.freeze
+    VERSION = '3.3.2'.freeze
   end
 end

--- a/lib/kitchen/provisioner/puppet/librarian.rb
+++ b/lib/kitchen/provisioner/puppet/librarian.rb
@@ -19,6 +19,7 @@
 
 require 'kitchen/errors'
 require 'kitchen/logging'
+require 'librarian/ui'
 
 module Kitchen
   module Provisioner
@@ -28,6 +29,34 @@ module Kitchen
       #
       class Librarian
         include Logging
+
+        class LoggerUI < ::Librarian::UI
+          attr_writer :logger
+
+          def initialize(logger)
+            @logger = logger
+          end
+
+          def warn(message = nil)
+            @logger.warn(message || yield)
+          end
+
+          def debug(message = nil)
+            @logger.debug(message || yield)
+          end
+
+          def error(message = nil)
+            @logger.error(message || yield)
+          end
+
+          def info(message = nil)
+            @logger.info(message || yield)
+          end
+
+          def confirm(message = nil)
+            @logger.info(message || yield)
+          end
+        end
 
         def initialize(puppetfile, path, logger = Kitchen.logger)
           @puppetfile = puppetfile
@@ -47,6 +76,7 @@ module Kitchen
           env = ::Librarian::Puppet::Environment.new(
             project_path: File.expand_path(File.dirname(puppetfile))
           )
+          env.ui = LoggerUI.new(@logger)
 
           env.config_db.local['path'] = path
           ::Librarian::Action::Resolve.new(env).run

--- a/lib/kitchen/provisioner/puppet/r10k.rb
+++ b/lib/kitchen/provisioner/puppet/r10k.rb
@@ -1,0 +1,73 @@
+# -*- encoding: utf-8 -*-
+
+#
+# Author:: Fletcher Nichol (<fnichol@nichol.ca>) Neill Turner (<neillwturner@gmail.com>) Dennis Lerch (<dennis.lerch@transporeon.com>)
+#
+# Copyright (C) 2018, Fletcher Nichol, Neill Turner, Dennis Lerch
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'kitchen/errors'
+require 'kitchen/logging'
+
+module Kitchen
+  module Provisioner
+    module Puppet
+      # Puppet module resolver that uses R10K and a Puppetfile to
+      # calculate # dependencies.
+      #
+      class R10K
+        include Logging
+
+        def initialize(puppetfile, path, logger = Kitchen.logger)
+          @puppetfile = puppetfile
+          @path = path
+          @logger = logger
+        end
+
+        def self.load!(logger = Kitchen.logger)
+          load_r10k!(logger)
+        end
+
+        def resolve
+          version = ::R10K::VERSION
+          info("Resolving module dependencies with R10K-Puppet #{version}...")
+          debug("Using Puppetfile from #{puppetfile}")
+
+          pf = ::R10K::Puppetfile.new(nil, path, puppetfile)
+          pf.load
+          pf.modules.each do |mod|
+            mod.sync
+          end
+        end
+
+        attr_reader :puppetfile, :path, :logger
+
+        def self.load_r10k!(logger)
+          require 'r10k/puppetfile'
+          #require 'r10k/action/puppetfile'
+
+          version = ::R10K::VERSION
+          logger.debug("R10K #{version} library loaded")
+        rescue LoadError => e
+          logger.fatal("The `r10k' gem is missing and must be installed" \
+            ' or cannot be properly activated. Run' \
+            ' `gem install r10k` or add the following to your' \
+            " Gemfile if you are using Bundler: `gem 'r10k'`.")
+          raise UserError,
+            "Could not load or activate R10K (#{e.message})"
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/provisioner/puppet/r10k.rb
+++ b/lib/kitchen/provisioner/puppet/r10k.rb
@@ -49,16 +49,13 @@ module Kitchen
 
           pf = ::R10K::Puppetfile.new(nil, path, puppetfile)
           pf.load
-          pf.modules.each do |mod|
-            mod.sync
-          end
+          pf.modules.map(&:sync)
         end
 
         attr_reader :puppetfile, :path, :logger
 
         def self.load_r10k!(logger)
           require 'r10k/puppetfile'
-          #require 'r10k/action/puppetfile'
 
           version = ::R10K::VERSION
           logger.debug("R10K #{version} library loaded")
@@ -68,7 +65,7 @@ module Kitchen
             ' `gem install r10k` or add the following to your' \
             " Gemfile if you are using Bundler: `gem 'r10k'`.")
           raise UserError,
-            "Could not load or activate R10K (#{e.message})"
+                "Could not load or activate R10K (#{e.message})"
         end
       end
     end

--- a/lib/kitchen/provisioner/puppet/r10k.rb
+++ b/lib/kitchen/provisioner/puppet/r10k.rb
@@ -44,6 +44,9 @@ module Kitchen
           info("Resolving module dependencies with R10K-Puppet #{version}...")
           debug("Using Puppetfile from #{puppetfile}")
 
+          ::R10K::Git::Cache.settings[:cache_root] = '.r10k/git'
+          ::R10K::Forge::ModuleRelease.settings[:cache_root] = '.r10k/cache'
+
           pf = ::R10K::Puppetfile.new(nil, path, puppetfile)
           pf.load
           pf.modules.each do |mod|

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -24,7 +24,6 @@
 require 'uri'
 require 'json'
 require 'kitchen'
-require 'kitchen/provisioner/puppet/librarian'
 
 module Kitchen
   class Busser
@@ -59,6 +58,7 @@ module Kitchen
       default_config :require_puppet_repo, true
       default_config :require_chef_for_busser, true
       default_config :resolve_with_librarian_puppet, true
+      default_config :resolve_with_r10k, false
       default_config :puppet_environment, nil
       default_config :puppet_environment_config_path do |provisioner|
         provisioner.calculate_path('environment.conf')
@@ -165,6 +165,7 @@ module Kitchen
       default_config :puppet_detailed_exitcodes, nil
       default_config :facter_file, nil
       default_config :librarian_puppet_ssl_file, nil
+      default_config :r10k_ssl_file, nil
 
       default_config :hiera_eyaml, false
       default_config :hiera_eyaml_key_remote_path, '/etc/puppet/secure/keys'
@@ -758,9 +759,16 @@ module Kitchen
 
       def load_needed_dependencies!
         return unless File.exist?(puppetfile)
-        return unless config[:resolve_with_librarian_puppet]
-        debug("Puppetfile found at #{puppetfile}, loading Librarian-Puppet")
-        Puppet::Librarian.load!(logger)
+        return unless config[:resolve_with_librarian_puppet] or config[:resolve_with_r10k]
+        if config[:resolve_with_librarian_puppet]
+          require 'kitchen/provisioner/puppet/librarian'
+          debug("Puppetfile found at #{puppetfile}, loading Librarian-Puppet")
+          Puppet::Librarian.load!(logger)
+        elsif config[:resolve_with_r10k]
+          require 'kitchen/provisioner/puppet/r10k'
+          debug("Puppetfile found at #{puppetfile}, loading R10K")
+          Puppet::R10K.load!(logger)
+        end
       end
 
       def tmpmodules_dir
@@ -898,6 +906,10 @@ module Kitchen
 
       def librarian_puppet_ssl_file
         config[:librarian_puppet_ssl_file]
+      end
+
+      def r10k_ssl_file
+        config[:r10k_puppet_ssl_file] || config[:librarian_puppet_ssl_file]
       end
 
       def puppet_cmd
@@ -1259,6 +1271,7 @@ module Kitchen
 
         FileUtils.mkdir_p(tmpmodules_dir)
         resolve_with_librarian if File.exist?(puppetfile) && config[:resolve_with_librarian_puppet]
+        resolve_with_r10k if File.exist?(puppetfile) && config[:resolve_with_r10k] &! config[:resolve_with_librarian_puppet]
         modules_to_copy = {}
 
         # If root dir (.) is a module, add it for copying
@@ -1408,10 +1421,20 @@ module Kitchen
       end
 
       def resolve_with_librarian
+        require 'kitchen/provisioner/puppet/librarian'
         Kitchen.mutex.synchronize do
           ENV['SSL_CERT_FILE'] = librarian_puppet_ssl_file if librarian_puppet_ssl_file
           Puppet::Librarian.new(puppetfile, tmpmodules_dir, logger).resolve
           ENV['SSL_CERT_FILE'] = '' if librarian_puppet_ssl_file
+        end
+      end
+
+      def resolve_with_r10k
+        require 'kitchen/provisioner/puppet/r10k'
+        Kitchen.mutex.synchronize do
+          ENV['SSL_CERT_FILE'] = r10k_ssl_file if r10k_ssl_file
+          Puppet::R10K.new(puppetfile, tmpmodules_dir, logger).resolve
+          ENV['SSL_CERT_FILE'] = '' if r10k_ssl_file
         end
       end
 

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -759,7 +759,7 @@ module Kitchen
 
       def load_needed_dependencies!
         return unless File.exist?(puppetfile)
-        return unless config[:resolve_with_librarian_puppet] or config[:resolve_with_r10k]
+        return unless config[:resolve_with_librarian_puppet] || config[:resolve_with_r10k]
         if config[:resolve_with_librarian_puppet]
           require 'kitchen/provisioner/puppet/librarian'
           debug("Puppetfile found at #{puppetfile}, loading Librarian-Puppet")
@@ -1271,7 +1271,7 @@ module Kitchen
 
         FileUtils.mkdir_p(tmpmodules_dir)
         resolve_with_librarian if File.exist?(puppetfile) && config[:resolve_with_librarian_puppet]
-        resolve_with_r10k if File.exist?(puppetfile) && config[:resolve_with_r10k] &! config[:resolve_with_librarian_puppet]
+        resolve_with_r10k if File.exist?(puppetfile) && config[:resolve_with_r10k] && !config[:resolve_with_librarian_puppet]
         modules_to_copy = {}
 
         # If root dir (.) is a module, add it for copying

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -59,6 +59,7 @@ ignore_spec_fixtures | false | don't copy spec/fixtures to avoid problems with s
 install_custom_facts| false | Install custom facts to yaml file at "/tmp/kitchen/facter/kitchen.rb"
 install_hiera | false | Installs `hiera-puppet` package. Not needed for puppet > 3.x.x
 librarian_puppet_ssl_file | nil | ssl certificate file for librarian-puppet
+r10k_ssl_file | nil | ssl certificate file for r10k
 manifest | puppet parses every .pp file in the manifests_path directory and its subdirectories | manifest(s) for puppet apply to run. If set to a file like 'site.pp' it will use the file in the mainfests_path.
 manifests_path | 'mainfests' | puppet repo manifests directory
 max_retries| 1 | maximum number of retry attempts of converge command
@@ -110,6 +111,7 @@ require_puppet_collections | true | Set if using puppet collections install (Pup
 require_puppet_omnibus | false | Set if using omnibus puppet install
 require_puppet_repo | true | Set if using a puppet install from yum or apt repo
 resolve_with_librarian_puppet | true | Use librarian_puppet to resolve modules if a Puppetfile is found
+resolve_with_r10k | true | Use r10k to resolve modules if a Puppetfile is found
 retry_on_exit_code| [] | Array of exit codes to retry converge command against
 update_package_repos| true| update OS repository metadata
 wait_for_retry| 30 | number of seconds to wait before retrying converge command

--- a/spec/kitchen/provisioner/puppet_agent_spec.rb
+++ b/spec/kitchen/provisioner/puppet_agent_spec.rb
@@ -16,17 +16,18 @@ describe Kitchen::Busser do
 end
 
 describe Kitchen::Provisioner::PuppetAgent do
-  let(:logged_output) { StringIO.new }
-  let(:logger)        { Logger.new(logged_output) }
-  let(:config)        { { test_base_path: '/kitchen' } }
-  let(:platform)      { Kitchen::Platform.new(name: 'ubuntu-14.04') }
-  let(:suite)         { Kitchen::Suite.new(name: 'suitey') }
-  let(:verifier)      { Kitchen::Verifier::Dummy.new }
-  let(:transport)     { Kitchen::Transport::Dummy.new }
-  let(:state_file)    { double('state_file') }
-  let(:state)         { {} }
-  let(:env)           { {} }
-  let(:driver) { Kitchen::Driver::Dummy.new }
+  let(:logged_output)   { StringIO.new }
+  let(:logger)          { Logger.new(logged_output) }
+  let(:config)          { { test_base_path: '/kitchen' } }
+  let(:platform)        { Kitchen::Platform.new(name: 'ubuntu-14.04') }
+  let(:suite)           { Kitchen::Suite.new(name: 'suitey') }
+  let(:verifier)        { Kitchen::Verifier::Dummy.new }
+  let(:transport)       { Kitchen::Transport::Dummy.new }
+  let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new(config) }
+  let(:state_file)      { double('state_file') }
+  let(:state)           { {} }
+  let(:env)             { {} }
+  let(:driver)          { Kitchen::Driver::Dummy.new }
 
   let(:provisioner_object) { Kitchen::Provisioner::PuppetAgent.new(config) }
 
@@ -42,6 +43,7 @@ describe Kitchen::Provisioner::PuppetAgent do
     Kitchen::Instance.new(
       verifier: verifier,
       driver: driver,
+      lifecycle_hooks: lifecycle_hooks,
       logger: logger,
       suite: suite,
       platform: platform,

--- a/spec/kitchen/provisioner/puppet_agent_spec.rb
+++ b/spec/kitchen/provisioner/puppet_agent_spec.rb
@@ -190,6 +190,10 @@ describe Kitchen::Provisioner::PuppetAgent do
         expect(provisioner[:librarian_puppet_ssl_file]).to eq(nil)
       end
 
+      it 'should not use r10k ssl file' do
+        expect(provisioner[:r10k_ssl_file]).to eq(nil)
+      end
+
       it 'should not find hiera eyaml key path' do
         expect(provisioner[:hiera_eyaml_key_path]).to eq(nil)
       end
@@ -245,6 +249,11 @@ describe Kitchen::Provisioner::PuppetAgent do
       end
 
       it 'should not resolve with librarian puppet' do
+        config[:resolve_with_r10k] = false
+        expect(provisioner[:resolve_with_r10k]).to eq(false)
+      end
+
+      it 'should not resolve with r10k' do
         config[:resolve_with_librarian_puppet] = false
         expect(provisioner[:resolve_with_librarian_puppet]).to eq(false)
       end

--- a/spec/kitchen/provisioner/puppet_apply_spec.rb
+++ b/spec/kitchen/provisioner/puppet_apply_spec.rb
@@ -23,6 +23,7 @@ describe Kitchen::Provisioner::PuppetApply do
   let(:suite)         { Kitchen::Suite.new(name: 'suitey') }
   let(:verifier)      { Kitchen::Verifier::Dummy.new }
   let(:transport)     { Kitchen::Transport::Dummy.new }
+  let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new(config) }
   let(:state_file)    { double('state_file') }
   let(:state)         { {} }
   let(:env)           { {} }
@@ -42,6 +43,7 @@ describe Kitchen::Provisioner::PuppetApply do
     Kitchen::Instance.new(
       verifier: verifier,
       driver: driver,
+      lifecycle_hooks: lifecycle_hooks,
       logger: logger,
       suite: suite,
       platform: platform,


### PR DESCRIPTION
Previously kitchen-puppet didn't configure Librarian-puppet with the logger from Kitchen, so all logging messages were lost when trying to resolve dependencies.

This adds a "UI" for the Librarian environment that forwards all log messages to the Kitchen logger.