### PR TITLE
Add Kitchen logger to Librarian

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'kitchen-docker', '~> 2.6.0'
+gem 'librarian-puppet', '~> 3.0.0'
 gem 'rake', '~> 10.4.2'
 gem 'rspec', '~> 3.3.0'
 gem 'rubocop', '~> 0.49.0'

--- a/lib/kitchen/provisioner/puppet/librarian.rb
+++ b/lib/kitchen/provisioner/puppet/librarian.rb
@@ -19,6 +19,7 @@
 
 require 'kitchen/errors'
 require 'kitchen/logging'
+require 'librarian/ui'
 
 module Kitchen
   module Provisioner
@@ -28,6 +29,34 @@ module Kitchen
       #
       class Librarian
         include Logging
+
+        class LoggerUI < ::Librarian::UI
+          attr_writer :logger
+
+          def initialize(logger)
+            @logger = logger
+          end
+
+          def warn(message = nil)
+            @logger.warn(message || yield)
+          end
+
+          def debug(message = nil)
+            @logger.debug(message || yield)
+          end
+
+          def error(message = nil)
+            @logger.error(message || yield)
+          end
+
+          def info(message = nil)
+            @logger.info(message || yield)
+          end
+
+          def confirm(message = nil)
+            @logger.info(message || yield)
+          end
+        end
 
         def initialize(puppetfile, path, logger = Kitchen.logger)
           @puppetfile = puppetfile
@@ -47,6 +76,7 @@ module Kitchen
           env = ::Librarian::Puppet::Environment.new(
             project_path: File.expand_path(File.dirname(puppetfile))
           )
+          env.ui = LoggerUI.new(@logger)
 
           env.config_db.local['path'] = path
           ::Librarian::Action::Resolve.new(env).run


### PR DESCRIPTION
Previously kitchen-puppet didn't configure Librarian-puppet with the logger from Kitchen, so all logging messages were lost when trying to resolve dependencies.

This adds a "UI" for the Librarian environment that forwards all log messages to the Kitchen logger.