### PR TITLE
Tweak puppet-agent Windows Installers

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -264,7 +264,6 @@ module Kitchen
                   Write-Host "Installer failed."
                   Exit 1
               }
-
               #{install_busser}
               #{custom_install_command}
             INSTALL
@@ -364,7 +363,6 @@ module Kitchen
                 Write-Host "Installer failed."
                 Exit 1
             }
-
             #{install_busser}
             #{custom_install_command}
           INSTALL

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -248,6 +248,7 @@ module Kitchen
             info("Installing puppet on #{puppet_platform}")
             info('Powershell is not recognised by core test-kitchen assuming it is present') unless powershell_shell?
             <<-INSTALL
+              #{custom_pre_install_command}
               if(Get-Command puppet -ErrorAction 0) { return; }
               $architecture = if( [Environment]::Is64BitOperatingSystem ) { 'x64' } else { 'x86' }
               if( '#{puppet_windows_version}' -eq 'latest' ) {
@@ -265,6 +266,7 @@ module Kitchen
               }
 
               #{install_busser}
+              #{custom_install_command}
             INSTALL
           else
             info('Installing puppet, will try to determine platform os')
@@ -346,6 +348,7 @@ module Kitchen
           info("Installing Puppet Collections on #{puppet_platform}")
           info('Powershell is not recognised by core test-kitchen assuming it is present') unless powershell_shell?
           <<-INSTALL
+            #{custom_pre_install_command}
             if(Get-Command puppet -ErrorAction 0) { return; }
             $architecture = if( [Environment]::Is64BitOperatingSystem ) { 'x64' } else { 'x86' }
             if( '#{puppet_windows_version}' -eq 'latest' ) {
@@ -363,6 +366,7 @@ module Kitchen
             }
 
             #{install_busser}
+            #{custom_install_command}
           INSTALL
         else
           info('Installing Puppet Collections, will try to determine platform os')

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -251,7 +251,7 @@ module Kitchen
               if(Get-Command puppet -ErrorAction 0) { return; }
               $architecture = if( [Environment]::Is64BitOperatingSystem ) { '-x64' } else { '' }
               if( '#{puppet_windows_version}' -eq 'latest' ) {
-                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-${architecture}-latest.msi"
+                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent${architecture}-latest.msi"
               } elseif( '#{puppet_windows_version}' -like '5.*' ) {
                   $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet5/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
               } else {

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -249,11 +249,11 @@ module Kitchen
             info('Powershell is not recognised by core test-kitchen assuming it is present') unless powershell_shell?
             <<-INSTALL
               if(Get-Command puppet -ErrorAction 0) { return; }
-              $architecture = if( [Environment]::Is64BitOperatingSystem ) { '-x64' } else { '' }
+              $architecture = if( [Environment]::Is64BitOperatingSystem ) { 'x64' } else { 'x86' }
               if( '#{puppet_windows_version}' -eq 'latest' ) {
-                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent${architecture}-latest.msi"
-              } elseif( '#{puppet_windows_version}' -like '5.*' ) {
-                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet5/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
+                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-${architecture}-latest.msi"
+              } elseif( '#{puppet_windows_version}' -match '(\\d)\\.' ) {
+                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet$($Matches[1])/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
               } else {
                   $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-#{puppet_windows_version}${architecture}.msi"
               }
@@ -350,10 +350,10 @@ module Kitchen
             $architecture = if( [Environment]::Is64BitOperatingSystem ) { 'x64' } else { 'x86' }
             if( '#{puppet_windows_version}' -eq 'latest' ) {
                 $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-${architecture}-latest.msi"
-            } elseif( '#{puppet_windows_version}' -like '5.*' ) {
-                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet5/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
+            } elseif( '#{puppet_windows_version}' -match '(\\d)\\.' ) {
+                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet$($Matches[1])/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
             } else {
-                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-#{puppet_windows_version}${architecture}.msi"
+                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
             }
             Invoke-WebRequest $MsiUrl -UseBasicParsing -OutFile "C:/puppet-agent.msi" #{posh_proxy_parm}
             $process = Start-Process -FilePath msiexec.exe -Wait -PassThru -ArgumentList '/qn', '/norestart', '/i', 'C:\\puppet-agent.msi'


### PR DESCRIPTION
It looks like Puppetlabs have changed up how the Windows installers are stored in their downloads directory.

I've tweaked the installer logic for puppet-agent to work with the new way that the MSI's are stored which should hopefully add a bit of future-proofing too.

I've also added support for pre/post install commands in Windows so that absolute worst case people can use their own logic.