### PR TITLE
Add puppet_windows_msi_url parameter

### DIFF
--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -72,7 +72,7 @@ module Kitchen
       default_config :puppet_apt_repo, 'http://apt.puppetlabs.com/puppetlabs-release-precise.deb'
       default_config :puppet_yum_repo, 'https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm'
       default_config :chef_bootstrap_url, 'https://www.chef.io/chef/install.sh'
-      default_config :puppet_windows_url, nil
+      default_config :puppet_windows_msi_url, nil
       default_config :puppet_logdest, nil
       default_config :custom_install_command, nil
       default_config :custom_pre_install_command, nil
@@ -252,8 +252,8 @@ module Kitchen
             <<-INSTALL
               #{custom_pre_install_command}
               if(Get-Command puppet -ErrorAction 0) { return; }
-              if( '#{puppet_windows_url}' -ne '') {
-                $MsiUrl = '#{puppet_windows_url}'
+              if( '#{puppet_windows_msi_url}' -ne '') {
+                $MsiUrl = '#{puppet_windows_msi_url}'
               }
               else
               {
@@ -359,8 +359,8 @@ module Kitchen
           <<-INSTALL
             #{custom_pre_install_command}
             if(Get-Command puppet -ErrorAction 0) { return; }
-            if( '#{puppet_windows_url}' -ne '') {
-              $MsiUrl = '#{puppet_windows_url}'
+            if( '#{puppet_windows_msi_url}' -ne '') {
+              $MsiUrl = '#{puppet_windows_msi_url}'
             }
             else
             {
@@ -988,8 +988,8 @@ module Kitchen
         config[:puppet_version] ? config[:puppet_version].to_s : 'latest'
       end
 
-      def puppet_windows_url
-        config[:puppet_windows_url]
+      def puppet_windows_msi_url
+        config[:puppet_windows_msi_url]
       end
 
       def puppet_environment_flag

--- a/lib/kitchen/provisioner/puppet_apply.rb
+++ b/lib/kitchen/provisioner/puppet_apply.rb
@@ -72,6 +72,7 @@ module Kitchen
       default_config :puppet_apt_repo, 'http://apt.puppetlabs.com/puppetlabs-release-precise.deb'
       default_config :puppet_yum_repo, 'https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm'
       default_config :chef_bootstrap_url, 'https://www.chef.io/chef/install.sh'
+      default_config :puppet_windows_url, nil
       default_config :puppet_logdest, nil
       default_config :custom_install_command, nil
       default_config :custom_pre_install_command, nil
@@ -251,13 +252,19 @@ module Kitchen
             <<-INSTALL
               #{custom_pre_install_command}
               if(Get-Command puppet -ErrorAction 0) { return; }
-              $architecture = if( [Environment]::Is64BitOperatingSystem ) { 'x64' } else { 'x86' }
-              if( '#{puppet_windows_version}' -eq 'latest' ) {
-                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-${architecture}-latest.msi"
-              } elseif( '#{puppet_windows_version}' -match '(\\d)\\.' ) {
-                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet$($Matches[1])/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
-              } else {
-                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-#{puppet_windows_version}${architecture}.msi"
+              if( '#{puppet_windows_url}' -ne '') {
+                $MsiUrl = '#{puppet_windows_url}'
+              }
+              else
+              {
+                $architecture = if( [Environment]::Is64BitOperatingSystem ) { 'x64' } else { 'x86' }
+                if( '#{puppet_windows_version}' -eq 'latest' ) {
+                    $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-${architecture}-latest.msi"
+                } elseif( '#{puppet_windows_version}' -match '(\\d)\\.' ) {
+                    $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet$($Matches[1])/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
+                } else {
+                    $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-#{puppet_windows_version}${architecture}.msi"
+                }
               }
               Invoke-WebRequest $MsiUrl -UseBasicParsing -OutFile "C:/puppet.msi" #{posh_proxy_parm}
               $process = Start-Process -FilePath msiexec.exe -Wait -PassThru -ArgumentList '/qn', '/norestart', '/i', 'C:\\puppet.msi'
@@ -352,13 +359,19 @@ module Kitchen
           <<-INSTALL
             #{custom_pre_install_command}
             if(Get-Command puppet -ErrorAction 0) { return; }
-            $architecture = if( [Environment]::Is64BitOperatingSystem ) { 'x64' } else { 'x86' }
-            if( '#{puppet_windows_version}' -eq 'latest' ) {
-                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-${architecture}-latest.msi"
-            } elseif( '#{puppet_windows_version}' -match '(\\d)\\.' ) {
-                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet$($Matches[1])/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
-            } else {
-                $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
+            if( '#{puppet_windows_url}' -ne '') {
+              $MsiUrl = '#{puppet_windows_url}'
+            }
+            else
+            {
+              $architecture = if( [Environment]::Is64BitOperatingSystem ) { 'x64' } else { 'x86' }
+              if( '#{puppet_windows_version}' -eq 'latest' ) {
+                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-${architecture}-latest.msi"
+              } elseif( '#{puppet_windows_version}' -match '(\\d)\\.' ) {
+                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet$($Matches[1])/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
+              } else {
+                  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-#{puppet_windows_version}-${architecture}.msi"
+              }
             }
             Invoke-WebRequest $MsiUrl -UseBasicParsing -OutFile "C:/puppet-agent.msi" #{posh_proxy_parm}
             $process = Start-Process -FilePath msiexec.exe -Wait -PassThru -ArgumentList '/qn', '/norestart', '/i', 'C:\\puppet-agent.msi'
@@ -973,6 +986,10 @@ module Kitchen
 
       def puppet_windows_version
         config[:puppet_version] ? config[:puppet_version].to_s : 'latest'
+      end
+
+      def puppet_windows_url
+        config[:puppet_windows_url]
       end
 
       def puppet_environment_flag

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -102,6 +102,7 @@ puppet_verbose| false| Extra information logging on puppet run
 puppet_show_diff| false| Show diffs for changes to config files during puppet runs.
 puppet_version | "latest"| desired version, affects apt and most installs.
 puppet_whitelist_exit_code | nil | Whitelist exit code expected from puppet run. Intended to be used together with `puppet_detailed_exitcodes`. You can also specify a yaml list here (you should use 0 and 2 for `puppet_detailed_exitcodes` to capture puppet runtime errors and allow multiple converge runs (without changes)).
+puppet_windows_msi_url | nil | The MSI to use to install Puppet on Windows, optional but may be needed when you want the latest version of a particular major Puppet release.
 puppet_yum_repo | https://yum.puppetlabs.com/ puppetlabs-release-el-6.noarch.rpm | yum repo RH/Centos6
 _for RH/Centos7 change to_ | https://yum.puppetlabs.com/ puppetlabs-release-el-7.noarch.rpm |
 puppet_yum_collections_repo | https://yum.puppetlabs.com/ puppet5/puppet-release-el-6.noarch.rpm | yum collections repo RH/Centos6


### PR DESCRIPTION
This adds the ability for the user to specify a URL for the MSI that should be used to install Puppet on Windows.
There's 2 main scenarios where I think this would be helpful:

1) Due to the way Puppetlabs store their downloads (https://downloads.puppetlabs.com/windows/index.html) it's hard to get the latest version of a given major release (e.g. Puppet6/Puppet7) automatically, and if Puppetlabs change the organisation of the download directory again this allows users to work around it fairly easily.

2) Sometimes people want to use a proxy download location (e.g. air gapped machine with access to only a local webserver)